### PR TITLE
Added function prototypes for theme_* to satisfy f19's gcc

### DIFF
--- a/gtk/engine/sugar-style.h
+++ b/gtk/engine/sugar-style.h
@@ -44,6 +44,11 @@ struct _SugarStyleClass
   GtkStyleClass parent_class;
 };
 
-G_GNUC_INTERNAL void sugar_style_register_type (GTypeModule *module);
+G_GNUC_INTERNAL 
+void         sugar_style_register_type  (GTypeModule *module);
+
+void         theme_init                 (GTypeModule *module);
+void         theme_exit                 (void);
+GtkRcStyle * theme_create_rc_style      (void);
 
 #endif /* __SUGAR_STYLE_H */


### PR DESCRIPTION
sugar-artwork refuses to build on a clean f19 install unless theme_init, theme_exit and the_create_rc_style are prototyped. I added prototypes for these functions.
