### PR TITLE
rename theme to Sugar

### DIFF
--- a/icons/index.theme
+++ b/icons/index.theme
@@ -1,6 +1,6 @@
 [Icon Theme]
-Name=OLPC
-Comment=Default OLPC Theme
+Name=Sugar
+Comment=Default Sugar Theme
 
 Directories=scalable/mimetypes,scalable/device,scalable/control,scalable/actions,scalable/status,scalable/emblems,scalable/categories
 


### PR DESCRIPTION
Theme was called OLPC. This patch changes it to Sugar. Does not impact icon theme search since the directory was already called sugar
