### PR TITLE
Action icons: add gtk-ok.svg as a symbolic link of dialog-ok.svg

### DIFF
--- a/icons/scalable/actions/Makefile.am
+++ b/icons/scalable/actions/Makefile.am
@@ -133,5 +133,6 @@ install-data-local: install-iconDATA
 	ln -sf activity-start.svg $(DESTDIR)$(icondir)/document-open.svg
 	ln -sf activity-stop.svg $(DESTDIR)$(icondir)/application-exit.svg
 	ln -sf dialog-ok.svg $(DESTDIR)$(icondir)/dialog-apply.svg
+	ln -sf dialog-ok.svg $(DESTDIR)$(icondir)/gtk-ok.svg
 	ln -sf media-playback-stop.svg $(DESTDIR)$(icondir)/process-stop.svg
 	(cd $(DESTDIR)$(icondir)/.. && $(ICONMAP) -c $(category))


### PR DESCRIPTION
The icon-naming-utils utility doesn't take care of this alias, so we
do the symbolic link in the Makefile.  The alias is needed for stock
icons with Gtk.STOCK_OK id.

Fixes #4010 .
