### PR TITLE
Fixes #3287, better journal icons

### DIFF
--- a/icons/scalable/mimetypes/Makefile.am
+++ b/icons/scalable/mimetypes/Makefile.am
@@ -12,7 +12,8 @@ icon_DATA =					\
 	text-uri-list.svg			\
 	text-x-generic.svg			\
 	text-x-python.svg			\
-	video-x-generic.svg
+	video-x-generic.svg			\
+	xo-bundle.svg
 
 EXTRA_DIST = $(icon_DATA)
 

--- a/icons/scalable/mimetypes/application-octet-stream.svg
+++ b/icons/scalable/mimetypes/application-octet-stream.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
-	<!ENTITY stroke_color "#010101">
-	<!ENTITY fill_color "#FFFFFF">
+	<!ENTITY stroke_color "#FFFFFF">
+	<!ENTITY fill_color "none">
 ]><svg enable-background="new 0 0 55 55" height="55px" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="clipping-data">
 	<g>
 		<g>

--- a/icons/scalable/mimetypes/application-x-generic.svg
+++ b/icons/scalable/mimetypes/application-x-generic.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
-	<!ENTITY stroke_color "#010101">
-	<!ENTITY fill_color "#FFFFFF">
+	<!ENTITY stroke_color "#FFFFFF">
+	<!ENTITY fill_color "none">
 ]><svg enable-background="new 0 0 55 55" height="55px" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="clipping-data">
 	<g>
 		<g>

--- a/icons/scalable/mimetypes/application-x-squeak-project.svg
+++ b/icons/scalable/mimetypes/application-x-squeak-project.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
-	<!ENTITY fill_color "#FFFFFF">
-	<!ENTITY stroke_color "#000000">
+	<!ENTITY stroke_color "#FFFFFF">
+	<!ENTITY fill_color "none">
 ]>
 <svg
    xmlns:svg="http://www.w3.org/2000/svg"

--- a/icons/scalable/mimetypes/audio-x-generic.svg
+++ b/icons/scalable/mimetypes/audio-x-generic.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
-	<!ENTITY stroke_color "#010101">
-	<!ENTITY fill_color "#FFFFFF">
+	<!ENTITY stroke_color "#FFFFFF">
+	<!ENTITY fill_color "none">
 ]><svg enable-background="new 0 0 55 55" height="55px" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="clipping-audio">
 	<g display="inline">
 		<g>

--- a/icons/scalable/mimetypes/document-generic.svg
+++ b/icons/scalable/mimetypes/document-generic.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  
 	  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
-	  <!ENTITY stroke_color "#010101">
-	  <!ENTITY fill_color "#FFFFFF">
+	  <!ENTITY stroke_color "#FFFFFF">
+	  <!ENTITY fill_color "none">
 	  ]>
 
 <svg enable-background="new 0 0 55 55" height="55px" version="1.1" 

--- a/icons/scalable/mimetypes/image-x-generic.svg
+++ b/icons/scalable/mimetypes/image-x-generic.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
-	<!ENTITY stroke_color "#010101">
-	<!ENTITY fill_color "#FFFFFF">
+	<!ENTITY stroke_color "#FFFFFF">
+	<!ENTITY fill_color "none">
 ]><svg enable-background="new 0 0 55 55" height="55px" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="clipping-image">
 	<g display="inline">
 		<g>

--- a/icons/scalable/mimetypes/text-uri-list.svg
+++ b/icons/scalable/mimetypes/text-uri-list.svg
@@ -1,6 +1,7 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
-	<!ENTITY stroke_color "#010101">
-	<!ENTITY fill_color "#FFFFFF">
+	<!ENTITY stroke_color "#FFFFFF">
+	<!ENTITY fill_color "none">
+	<!ENTITY line_color "#FFFFFF">
 ]><svg enable-background="new 0 0 55 55" height="55px" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="clipping-url_1_">
 	<g display="inline">
 		<g>
@@ -9,14 +10,14 @@
 		</g>
 	</g>
 	<g display="inline">
-		<circle cx="27.375" cy="33.5" fill="&stroke_color;" r="9.951"/>
+		<circle cx="27.375" cy="33.5" fill="&fill_color;" stroke="&line_color;" r="9.951"/>
 		<g>
-			<path d="M27.376,23.549c0,0-5.603,4.197-5.603,9.988s5.603,9.914,5.603,9.914" fill="none" stroke="&fill_color;" stroke-width="1.5"/>
-			<path d="M27.376,23.549c0,0,5.532,4.57,5.532,9.988     c0,5.419-5.532,9.914-5.532,9.914" fill="none" stroke="&fill_color;" stroke-width="1.5"/>
-			<line fill="none" stroke="&fill_color;" stroke-width="1.5" x1="27.376" x2="27.376" y1="23.549" y2="43.451"/>
-			<line fill="none" stroke="&fill_color;" stroke-width="1.5" x1="27.376" x2="27.376" y1="23.549" y2="43.451"/>
-			<line fill="none" stroke="&fill_color;" stroke-width="1.5" x1="27.376" x2="27.376" y1="23.549" y2="43.451"/>
-			<line fill="none" stroke="&fill_color;" stroke-width="1.5" x1="17.423" x2="37.326" y1="33.5" y2="33.5"/>
+			<path d="M27.376,23.549c0,0-5.603,4.197-5.603,9.988s5.603,9.914,5.603,9.914" fill="none" stroke="&line_color;" stroke-width="1.5"/>
+			<path d="M27.376,23.549c0,0,5.532,4.57,5.532,9.988     c0,5.419-5.532,9.914-5.532,9.914" fill="none" stroke="&line_color;" stroke-width="1.5"/>
+			<line fill="none" stroke="&line_color;" stroke-width="1.5" x1="27.376" x2="27.376" y1="23.549" y2="43.451"/>
+			<line fill="none" stroke="&line_color;" stroke-width="1.5" x1="27.376" x2="27.376" y1="23.549" y2="43.451"/>
+			<line fill="none" stroke="&line_color;" stroke-width="1.5" x1="27.376" x2="27.376" y1="23.549" y2="43.451"/>
+			<line fill="none" stroke="&line_color;" stroke-width="1.5" x1="17.423" x2="37.326" y1="33.5" y2="33.5"/>
 		</g>
 	</g>
 </g></svg>

--- a/icons/scalable/mimetypes/text-x-generic.svg
+++ b/icons/scalable/mimetypes/text-x-generic.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
-	<!ENTITY stroke_color "#010101">
-	<!ENTITY fill_color "#FFFFFF">
+	<!ENTITY stroke_color "#FFFFFF">
+	<!ENTITY fill_color "none">
 ]><svg enable-background="new 0 0 55 55" height="55px" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="clipping-text">
 	<g display="inline">
 		<g>

--- a/icons/scalable/mimetypes/text-x-python.svg
+++ b/icons/scalable/mimetypes/text-x-python.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
-	<!ENTITY stroke_color "#000000">
-	<!ENTITY fill_color "#ffffff">
+	<!ENTITY stroke_color "#FFFFFF">
+	<!ENTITY fill_color "none">
 ]><svg enable-background="new 0 0 55 55"
     height="55px" id="svg2"
     inkscape:version="0.48.4 r9939"

--- a/icons/scalable/mimetypes/video-x-generic.svg
+++ b/icons/scalable/mimetypes/video-x-generic.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
-	<!ENTITY stroke_color "#010101">
-	<!ENTITY fill_color "#FFFFFF">
+	<!ENTITY stroke_color "#FFFFFF">
+	<!ENTITY fill_color "none">
 ]><svg enable-background="new 0 0 55 55" height="55px" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="clipping-video">
 	<g display="inline">
 		<g>

--- a/icons/scalable/mimetypes/xo-bundle.svg
+++ b/icons/scalable/mimetypes/xo-bundle.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<!DOCTYPE svg  PUBLIC "-//W3C//DTD SVG 1.1//EN"
+    "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+    <!ENTITY stroke_color "#FFFFFF">
+    <!ENTITY fill_color "none">
+    ]>
+<svg height="55px" viewBox="0 0 55 55" width="55px" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <path d="m 7,14 5,-5 10,0 5,5 20,0 0,31 -40,0 z" style="fill:&fill_color;;stroke:&stroke_color;;stroke-width:3;stroke-linecap:round;stroke-linejoin:round" />
+      <g transform="translate(14.5,17.25)">
+          <g transform="scale(.45)">
+              <path d="M 43.82,6.088 L 22.876,6.088 L 10.932,18.027 L 10.932,48.914 L 43.819,48.914 L 43.82,6.088 z" fill="&fill_color;" stroke="&stroke_color;" stroke-width="5" />
+              <polyline fill="none" points="10.932,20.027 24.876,20.027 24.876,6.088" stroke="&stroke_color;" stroke-width="5"/>
+          </g>
+      </g>
+</svg>


### PR DESCRIPTION
This also depends on my pull request on (https://github.com/sugarlabs/sugar-toolkit-gtk3/pull/77) sugar-toolkit-gtk3. "This split the bundle icon from the docs icon so I could edit it in my pr on sugar-artwork" The xo-bundle icon is based of the user-documents icon
