### PR TITLE
Remove double line in menuitem separators

### DIFF
--- a/gtk3/theme/gtk-widgets.css.em
+++ b/gtk3/theme/gtk-widgets.css.em
@@ -463,7 +463,7 @@ SugarPaletteWindow SugarGroupBox *:insensitive {
 }
 
 .menuitem.separator {
-    padding: $(subcell_size)px 0px;
+    padding: 0;
 }
 
 SugarPaletteHeader.menuitem {
@@ -475,7 +475,7 @@ SugarPaletteHeader.menuitem:prelight {
 }
 
 SugarPaletteHeaderSeparator.menuitem.separator {
-    padding: 0px 0px $(subcell_size)px 0px;
+    padding: 0;
 }
 
 .tooltip {


### PR DESCRIPTION
We used padding in menuitem separators to add space between the
separator line and the items.  The original Sugar theme had a space of 1
subcell above and below the line.

Padding worked fine in GTK+ packaged in F18.  At that time I first tried
margin, but didn't work.

Now with sugar-build in F20 we see a double line.  Painting the border
yellow we can see what is happening (see picture attached to this PR).

The proper fix should be changing padding to margin.  But turns out
margin is not working yet.  I'll report this to GTK+.  In the mean time,
I think loosing the space is a good compromise to prevent the ugly
double line.
