### PR TITLE
icon for audio input

### DIFF
--- a/icons/scalable/device/Makefile.am
+++ b/icons/scalable/device/Makefile.am
@@ -62,6 +62,7 @@ icon_DATA =				\
 	male-6.svg			\
 	male-7.svg			\
 	media.svg			\
+	media-audio-input.svg		\
 	media-optical.svg		\
 	media-disk.svg			\
 	media-flash-sd.svg		\

--- a/icons/scalable/device/media-audio-input.svg
+++ b/icons/scalable/device/media-audio-input.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
+	<!ENTITY stroke_color "#010101">
+	<!ENTITY fill_color "#FFFFFF">
+]><svg enable-background="new 0 0 55 55" height="55px" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="record-audio">
+	<g display="inline">
+		<polygon fill="&fill_color;" points="    8.872,38.893 13.296,43.314 38.942,21.406 30.782,13.246   " stroke="&stroke_color;" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.5"/>
+		<circle cx="37.371" cy="14.759" fill="&fill_color;" r="8.757" stroke="&stroke_color;" stroke-linejoin="round" stroke-width="3.5"/>
+		<path d="M10.829,40.85    c-3.607,3.607-1.485,13.146,13.332,4.596C35.687,38.912,43.122,44.297,44.464,51" fill="none" stroke="&stroke_color;" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.5"/>
+	</g>
+</g></svg>


### PR DESCRIPTION
Of general utility, but specifically needed for the microphone level
adjustment patch. Based on the microphone icon used in the Measure
activity.

(Part of a series of patches to fix SL #800)

```
See [1] and [2] for the Design Team discussion.

[1] http://wiki.sugarlabs.org/go/File:MicLevels.png
[2] http://lists.sugarlabs.org/archive/sugar-devel/2014-March/047640.html
```
