### PR TITLE
Fix clipboard icon size -  Fixes #4751

### DIFF
--- a/gtk3/theme/gtk-widgets.css.em
+++ b/gtk3/theme/gtk-widgets.css.em
@@ -572,8 +572,8 @@ SugarPaletteWindowWidget SugarRadioToolButton .button {
 }
 
 .toolbar GtkToolButton .button,
-.toolbar SugarRadioToolButton *,
-SugarPaletteWindowWidget SugarRadioToolButton *,
+.toolbar SugarRadioToolButton .button,
+SugarPaletteWindowWidget SugarRadioToolButton .button,
 SugarPaletteWindowWidget GtkToolButton .button {
     background-color: transparent;
     border-radius: $(toolbutton_padding)px;


### PR DESCRIPTION
The origi of this problem was apply the padding rule to all the objects
internal to a SugarRadioToolButton. SugarClipboardIcon inherit the rule
and is affected, because have a button and a label inside.
The label is invisible, but with the padding enlarge the button.

Manuel said asterisks should not be used in the css theme, but few are present,
this is one case one using the asterisk have unintended consequences.

Signed-off-by: Gonzalo Odiard godiard@sugarlabs.org
