### PR TITLE
Fix wrong styling for column-header.button

### DIFF
--- a/gtk3/theme/gtk-widgets.css.em
+++ b/gtk3/theme/gtk-widgets.css.em
@@ -214,6 +214,13 @@ GtkTreeView {
     background-color: @button_grey;
 }
 
+column-header .button,
+column-header .button:hover:active {
+    border-radius: 0px;
+    background-color: @button_grey;
+    border-width: 0px;
+}
+
 GtkTreeView row:nth-child(even) {
     background-color: @row_even;
 }


### PR DESCRIPTION
This patch set the border-radius of column header button to 0px
so, this didnt show rounded anymore.

![Fix, image in #3962](https://cloud.githubusercontent.com/assets/2650479/5429131/bd3ecd8c-83c7-11e4-9aed-1dedfdaa10bb.png)

Fixes SL#3962
