### PR TITLE
Use `sugar:attach-points` instead of deprecated `.icon` file feature

### DIFF
--- a/icons/scalable/device/Makefile.am
+++ b/icons/scalable/device/Makefile.am
@@ -6,27 +6,16 @@ icon_DATA =				\
 	backup.svg			\
 	backup-backup.svg		\
 	backup-restore.svg		\
-	battery-000.icon		\
 	battery-000.svg			\
-	battery-010.icon		\
 	battery-010.svg			\
-	battery-020.icon		\
 	battery-020.svg			\
-	battery-030.icon		\
 	battery-030.svg			\
-	battery-040.icon		\
 	battery-040.svg			\
-	battery-050.icon		\
 	battery-050.svg			\
-	battery-060.icon		\
 	battery-060.svg			\
-	battery-070.icon		\
 	battery-070.svg			\
-	battery-080.icon		\
 	battery-080.svg			\
-	battery-090.icon		\
 	battery-090.svg			\
-	battery-100.icon		\
 	battery-100.svg			\
 	battery-charging-000.svg	\
 	battery-charging-010.svg	\
@@ -76,32 +65,19 @@ icon_DATA =				\
 	network-adhoc-11.svg		\
 	network-gsm.svg			\
 	network-mesh.svg		\
-	network-mesh.icon		\
 	network-wired.svg		\
 	network-wireless-000.svg	\
-	network-wireless-000.icon	\
 	network-wireless-020.svg	\
-	network-wireless-020.icon	\
 	network-wireless-040.svg	\
-	network-wireless-040.icon	\
 	network-wireless-060.svg	\
-	network-wireless-060.icon	\
 	network-wireless-080.svg	\
-	network-wireless-080.icon	\
 	network-wireless-100.svg	\
-	network-wireless-100.icon	\
 	network-wireless-connected-000.svg	\
-	network-wireless-connected-000.icon	\
 	network-wireless-connected-020.svg	\
-	network-wireless-connected-020.icon	\
 	network-wireless-connected-040.svg	\
-	network-wireless-connected-040.icon	\
 	network-wireless-connected-060.svg	\
-	network-wireless-connected-060.icon	\
 	network-wireless-connected-080.svg	\
-	network-wireless-connected-080.icon	\
 	network-wireless-connected-100.svg	\
-	network-wireless-connected-100.icon	\
 	printer.svg			\
 	school-server.svg			\
 	speaker-000.svg			\

--- a/icons/scalable/device/battery-000.icon
+++ b/icons/scalable/device/battery-000.icon
@@ -1,2 +1,0 @@
-[Icon Data]
-AttachPoints=948,697

--- a/icons/scalable/device/battery-000.svg
+++ b/icons/scalable/device/battery-000.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
 	<!ENTITY stroke_color "#010101">
 	<!ENTITY fill_color "#ffffff">
-]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="battery-000">
+]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px" sugar:attach-points="948,697"><g display="block" id="battery-000">
 	
 		<polygon display="inline" fill="&stroke_color;" points="   2.29,39.721 47.994,39.721 47.994,34.393 53.037,34.393 53.037,20.253 47.994,20.253 47.994,14.923 2.29,14.923  " stroke="&stroke_color;" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.5"/>
 </g></svg>

--- a/icons/scalable/device/battery-010.icon
+++ b/icons/scalable/device/battery-010.icon
@@ -1,2 +1,0 @@
-[Icon Data]
-AttachPoints=948,697

--- a/icons/scalable/device/battery-010.svg
+++ b/icons/scalable/device/battery-010.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
 	<!ENTITY stroke_color "#010101">
 	<!ENTITY fill_color "#ffffff">
-]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="battery-010">
+]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px" sugar:attach-points="948,697"><g display="block" id="battery-010">
 	<polygon display="inline" fill="&stroke_color;" points="2.29,39.721 47.994,39.721 47.994,34.393 53.037,34.393 53.037,20.253    47.994,20.253 47.994,14.923 2.29,14.923  "/>
 	<rect display="inline" fill="&fill_color;" height="25.007" width="5.074" x="2.29" y="14.923"/>
 	

--- a/icons/scalable/device/battery-020.icon
+++ b/icons/scalable/device/battery-020.icon
@@ -1,2 +1,0 @@
-[Icon Data]
-AttachPoints=948,697

--- a/icons/scalable/device/battery-020.svg
+++ b/icons/scalable/device/battery-020.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
 	<!ENTITY stroke_color "#010101">
 	<!ENTITY fill_color "#ffffff">
-]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="battery-020">
+]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px" sugar:attach-points="948,697"><g display="block" id="battery-020">
 	<polygon display="inline" fill="&stroke_color;" points="2.29,39.721 47.994,39.721 47.994,34.393 53.037,34.393 53.037,20.253    47.994,20.253 47.994,14.923 2.29,14.923  "/>
 	<rect display="inline" fill="&fill_color;" height="25.007" width="10.149" x="2.29" y="14.923"/>
 	

--- a/icons/scalable/device/battery-030.icon
+++ b/icons/scalable/device/battery-030.icon
@@ -1,2 +1,0 @@
-[Icon Data]
-AttachPoints=948,697

--- a/icons/scalable/device/battery-030.svg
+++ b/icons/scalable/device/battery-030.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
 	<!ENTITY stroke_color "#010101">
 	<!ENTITY fill_color "#ffffff">
-]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="battery-030">
+]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px" sugar:attach-points="948,697"><g display="block" id="battery-030">
 	<polygon display="inline" fill="&stroke_color;" points="2.29,39.721 47.994,39.721 47.994,34.393 53.037,34.393 53.037,20.253    47.994,20.253 47.994,14.923 2.29,14.923  "/>
 	<rect display="inline" fill="&fill_color;" height="25.007" width="15.226" x="2.29" y="14.923"/>
 	

--- a/icons/scalable/device/battery-040.icon
+++ b/icons/scalable/device/battery-040.icon
@@ -1,2 +1,0 @@
-[Icon Data]
-AttachPoints=948,697

--- a/icons/scalable/device/battery-040.svg
+++ b/icons/scalable/device/battery-040.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
 	<!ENTITY stroke_color "#010101">
 	<!ENTITY fill_color "#ffffff">
-]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="battery-040">
+]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px" sugar:attach-points="948,697"><g display="block" id="battery-040">
 	<polygon display="inline" fill="&stroke_color;" points="2.29,39.721 47.994,39.721 47.994,34.393 53.037,34.393 53.037,20.253    47.994,20.253 47.994,14.923 2.29,14.923  "/>
 	<rect display="inline" fill="&fill_color;" height="25.007" width="20.301" x="2.29" y="14.923"/>
 	

--- a/icons/scalable/device/battery-050.icon
+++ b/icons/scalable/device/battery-050.icon
@@ -1,2 +1,0 @@
-[Icon Data]
-AttachPoints=948,697

--- a/icons/scalable/device/battery-050.svg
+++ b/icons/scalable/device/battery-050.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
 	<!ENTITY stroke_color "#010101">
 	<!ENTITY fill_color "#ffffff">
-]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="battery-050">
+]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"v><g display="block" id="battery-050">
 	<polygon display="inline" fill="&stroke_color;" points="2.29,39.721 47.994,39.721 47.994,34.393 53.037,34.393 53.037,20.253    47.994,20.253 47.994,14.923 2.29,14.923  "/>
 	<rect display="inline" fill="&fill_color;" height="25.007" width="25.376" x="2.29" y="14.923"/>
 	

--- a/icons/scalable/device/battery-060.icon
+++ b/icons/scalable/device/battery-060.icon
@@ -1,2 +1,0 @@
-[Icon Data]
-AttachPoints=948,697

--- a/icons/scalable/device/battery-060.svg
+++ b/icons/scalable/device/battery-060.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
 	<!ENTITY stroke_color "#010101">
 	<!ENTITY fill_color "#ffffff">
-]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="battery-060">
+]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px" sugar:attach-points="948,697"><g display="block" id="battery-060">
 	<polygon display="inline" fill="&stroke_color;" points="2.29,39.721 47.994,39.721 47.994,34.393 53.037,34.393 53.037,20.253    47.994,20.253 47.994,14.923 2.29,14.923  "/>
 	<rect display="inline" fill="&fill_color;" height="25.007" width="30.452" x="2.29" y="14.923"/>
 	

--- a/icons/scalable/device/battery-070.icon
+++ b/icons/scalable/device/battery-070.icon
@@ -1,2 +1,0 @@
-[Icon Data]
-AttachPoints=948,697

--- a/icons/scalable/device/battery-070.svg
+++ b/icons/scalable/device/battery-070.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
 	<!ENTITY stroke_color "#010101">
 	<!ENTITY fill_color "#ffffff">
-]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="battery-070">
+]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px" sugar:attach-points="948,697"><g display="block" id="battery-070">
 	<polygon display="inline" fill="&stroke_color;" points="2.29,39.721 47.994,39.721 47.994,34.393 53.037,34.393 53.037,20.253    47.994,20.253 47.994,14.923 2.29,14.923  "/>
 	<rect display="inline" fill="&fill_color;" height="25.007" width="35.528" x="2.29" y="14.923"/>
 	

--- a/icons/scalable/device/battery-080.icon
+++ b/icons/scalable/device/battery-080.icon
@@ -1,2 +1,0 @@
-[Icon Data]
-AttachPoints=948,697

--- a/icons/scalable/device/battery-080.svg
+++ b/icons/scalable/device/battery-080.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
 	<!ENTITY stroke_color "#010101">
 	<!ENTITY fill_color "#ffffff">
-]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="battery-080">
+]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px" sugar:attach-points="948,697"><g display="block" id="battery-080">
 	<polygon display="inline" fill="&stroke_color;" points="2.29,39.721 47.994,39.721 47.994,34.393 53.037,34.393 53.037,20.253    47.994,20.253 47.994,14.923 2.29,14.923  "/>
 	<rect display="inline" fill="&fill_color;" height="25.007" width="40.604" x="2.29" y="14.923"/>
 	

--- a/icons/scalable/device/battery-090.icon
+++ b/icons/scalable/device/battery-090.icon
@@ -1,2 +1,0 @@
-[Icon Data]
-AttachPoints=948,697

--- a/icons/scalable/device/battery-090.svg
+++ b/icons/scalable/device/battery-090.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
 	<!ENTITY stroke_color "#010101">
 	<!ENTITY fill_color "#ffffff">
-]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="battery-090">
+]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px" sugar:attach-points="948,697"><g display="block" id="battery-090">
 	<polygon display="inline" fill="&stroke_color;" points="2.29,39.721 47.994,39.721 47.994,34.393 53.037,34.393 53.037,20.253    47.994,20.253 47.994,14.923 2.29,14.923  "/>
 	<rect display="inline" fill="&fill_color;" height="25.007" width="45.681" x="2.29" y="14.923"/>
 	

--- a/icons/scalable/device/battery-100.icon
+++ b/icons/scalable/device/battery-100.icon
@@ -1,2 +1,0 @@
-[Icon Data]
-AttachPoints=948,697

--- a/icons/scalable/device/battery-100.svg
+++ b/icons/scalable/device/battery-100.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
 	<!ENTITY stroke_color "#010101">
 	<!ENTITY fill_color "#ffffff">
-]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="battery-100">
+]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px" sugar:attach-points="948,697"><g display="block" id="battery-100">
 	
 		<polygon display="inline" fill="&fill_color;" points="   2.29,39.721 47.994,39.721 47.994,34.393 53.037,34.393 53.037,20.253 47.994,20.253 47.994,14.923 2.29,14.923  " stroke="&stroke_color;" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.5"/>
 </g></svg>

--- a/icons/scalable/device/network-mesh.icon
+++ b/icons/scalable/device/network-mesh.icon
@@ -1,2 +1,0 @@
-[Icon Data]
-AttachPoints=970,850

--- a/icons/scalable/device/network-wireless-000.icon
+++ b/icons/scalable/device/network-wireless-000.icon
@@ -1,2 +1,0 @@
-[Icon Data]
-AttachPoints=970,850

--- a/icons/scalable/device/network-wireless-000.svg
+++ b/icons/scalable/device/network-wireless-000.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
 	<!ENTITY stroke_color "#010101">
 	<!ENTITY fill_color "#ffffff">
-]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="network-wireless-000">
+]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px" sugar:attach-points="970,850"><g display="block" id="network-wireless-000">
 	<path d="   M46.375,27.498c0,10.494-8.507,19.002-19,19.002s-19-8.508-19-19.002c0-10.49,8.507-18.998,19-18.998S46.375,17.003,46.375,27.498z   " display="inline" fill="&stroke_color;" stroke="&stroke_color;" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.5"/>
 </g></svg>

--- a/icons/scalable/device/network-wireless-020.icon
+++ b/icons/scalable/device/network-wireless-020.icon
@@ -1,2 +1,0 @@
-[Icon Data]
-AttachPoints=970,850

--- a/icons/scalable/device/network-wireless-020.svg
+++ b/icons/scalable/device/network-wireless-020.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
 	<!ENTITY stroke_color "#010101">
 	<!ENTITY fill_color "#ffffff">
-]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="network-wireless-020">
+]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px" sugar:attach-points="970,850"><g display="block" id="network-wireless-020">
 	<path d="M46.375,27.498c0,10.494-8.507,19.002-19,19.002s-19-8.508-19-19.002   c0-10.49,8.507-18.998,19-18.998S46.375,17.003,46.375,27.498z" display="inline" fill="&stroke_color;"/>
 	<g display="inline">
 		<g>

--- a/icons/scalable/device/network-wireless-040.icon
+++ b/icons/scalable/device/network-wireless-040.icon
@@ -1,2 +1,0 @@
-[Icon Data]
-AttachPoints=970,850

--- a/icons/scalable/device/network-wireless-040.svg
+++ b/icons/scalable/device/network-wireless-040.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
 	<!ENTITY stroke_color "#010101">
 	<!ENTITY fill_color "#ffffff">
-]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="network-wireless-040">
+]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px" sugar:attach-points="970,850"><g display="block" id="network-wireless-040">
 	<path d="M46.375,27.498c0,10.494-8.507,19.002-19,19.002s-19-8.508-19-19.002   c0-10.49,8.507-18.998,19-18.998S46.375,17.003,46.375,27.498z" display="inline" fill="&stroke_color;"/>
 	<g display="inline">
 		<g>

--- a/icons/scalable/device/network-wireless-060.icon
+++ b/icons/scalable/device/network-wireless-060.icon
@@ -1,2 +1,0 @@
-[Icon Data]
-AttachPoints=970,850

--- a/icons/scalable/device/network-wireless-060.svg
+++ b/icons/scalable/device/network-wireless-060.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
 	<!ENTITY stroke_color "#010101">
 	<!ENTITY fill_color "#ffffff">
-]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="network-wireless-060">
+]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px" sugar:attach-points="970,850"><g display="block" id="network-wireless-060">
 	<path d="M46.375,27.498c0,10.494-8.507,19.002-19,19.002s-19-8.508-19-19.002   c0-10.49,8.507-18.998,19-18.998S46.375,17.003,46.375,27.498z" display="inline" fill="&stroke_color;"/>
 	<g display="inline">
 		<g>

--- a/icons/scalable/device/network-wireless-080.icon
+++ b/icons/scalable/device/network-wireless-080.icon
@@ -1,2 +1,0 @@
-[Icon Data]
-AttachPoints=970,850

--- a/icons/scalable/device/network-wireless-080.svg
+++ b/icons/scalable/device/network-wireless-080.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
 	<!ENTITY stroke_color "#010101">
 	<!ENTITY fill_color "#ffffff">
-]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="network-wireless-080">
+]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px" sugar:attach-points="970,850"><g display="block" id="network-wireless-080">
 	<path d="M46.375,27.498c0,10.494-8.507,19.002-19,19.002s-19-8.508-19-19.002   c0-10.49,8.507-18.998,19-18.998S46.375,17.003,46.375,27.498z" display="inline" fill="&stroke_color;"/>
 	<g display="inline">
 		<g>

--- a/icons/scalable/device/network-wireless-100.icon
+++ b/icons/scalable/device/network-wireless-100.icon
@@ -1,2 +1,0 @@
-[Icon Data]
-AttachPoints=970,850

--- a/icons/scalable/device/network-wireless-100.svg
+++ b/icons/scalable/device/network-wireless-100.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
 	<!ENTITY stroke_color "#010101">
 	<!ENTITY fill_color "#ffffff">
-]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="network-wireless-100">
+]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px" sugar:attach-points="970,850"><g display="block" id="network-wireless-100">
 	<g display="inline">
 		<g>
 			<defs>

--- a/icons/scalable/device/network-wireless-connected-000.icon
+++ b/icons/scalable/device/network-wireless-connected-000.icon
@@ -1,2 +1,0 @@
-[Icon Data]
-AttachPoints=970,850

--- a/icons/scalable/device/network-wireless-connected-000.svg
+++ b/icons/scalable/device/network-wireless-connected-000.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
 	<!ENTITY stroke_color "#010101">
 	<!ENTITY fill_color "#ffffff">
-]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="network-wireless-connected-000">
+]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px" sugar:attach-points="970,850"><g display="block" id="network-wireless-connected-000">
 	<path d="   M46.375,27.498c0,10.494-8.507,19.002-19,19.002s-19-8.508-19-19.002c0-10.49,8.507-18.998,19-18.998S46.375,17.003,46.375,27.498z   " display="inline" fill="&stroke_color;" stroke="&stroke_color;" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.5"/>
 	<g display="inline">
 		<path d="M9.471,45.697    c-9.958-9.958-9.959-26.104,0-36.062" fill="none" stroke="&stroke_color;" stroke-linecap="round" stroke-width="3.5"/>

--- a/icons/scalable/device/network-wireless-connected-020.icon
+++ b/icons/scalable/device/network-wireless-connected-020.icon
@@ -1,2 +1,0 @@
-[Icon Data]
-AttachPoints=970,850

--- a/icons/scalable/device/network-wireless-connected-020.svg
+++ b/icons/scalable/device/network-wireless-connected-020.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
 	<!ENTITY stroke_color "#010101">
 	<!ENTITY fill_color "#ffffff">
-]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="network-wireless-connected-020">
+]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px" sugar:attach-points="970,850"><g display="block" id="network-wireless-connected-020">
 	<path d="M46.375,27.498c0,10.494-8.507,19.002-19,19.002s-19-8.508-19-19.002   c0-10.49,8.507-18.998,19-18.998S46.375,17.003,46.375,27.498z" display="inline" fill="&stroke_color;"/>
 	<g display="inline">
 		<g>

--- a/icons/scalable/device/network-wireless-connected-040.icon
+++ b/icons/scalable/device/network-wireless-connected-040.icon
@@ -1,2 +1,0 @@
-[Icon Data]
-AttachPoints=970,850

--- a/icons/scalable/device/network-wireless-connected-040.svg
+++ b/icons/scalable/device/network-wireless-connected-040.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
 	<!ENTITY stroke_color "#010101">
 	<!ENTITY fill_color "#ffffff">
-]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="network-wireless-connected-040">
+]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px" sugar:attach-points="970,850"><g display="block" id="network-wireless-connected-040">
 	<path d="M46.375,27.498c0,10.494-8.507,19.002-19,19.002s-19-8.508-19-19.002   c0-10.49,8.507-18.998,19-18.998S46.375,17.003,46.375,27.498z" display="inline" fill="&stroke_color;"/>
 	<g display="inline">
 		<g>

--- a/icons/scalable/device/network-wireless-connected-060.icon
+++ b/icons/scalable/device/network-wireless-connected-060.icon
@@ -1,2 +1,0 @@
-[Icon Data]
-AttachPoints=970,850

--- a/icons/scalable/device/network-wireless-connected-060.svg
+++ b/icons/scalable/device/network-wireless-connected-060.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
 	<!ENTITY stroke_color "#010101">
 	<!ENTITY fill_color "#ffffff">
-]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="network-wireless-connected-060">
+]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px" sugar:attach-points="970,850"><g display="block" id="network-wireless-connected-060">
 	<path d="M46.375,27.498c0,10.494-8.507,19.002-19,19.002s-19-8.508-19-19.002   c0-10.49,8.507-18.998,19-18.998S46.375,17.003,46.375,27.498z" display="inline" fill="&stroke_color;"/>
 	<g display="inline">
 		<g>

--- a/icons/scalable/device/network-wireless-connected-080.icon
+++ b/icons/scalable/device/network-wireless-connected-080.icon
@@ -1,2 +1,0 @@
-[Icon Data]
-AttachPoints=970,850

--- a/icons/scalable/device/network-wireless-connected-080.svg
+++ b/icons/scalable/device/network-wireless-connected-080.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
 	<!ENTITY stroke_color "#010101">
 	<!ENTITY fill_color "#ffffff">
-]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="network-wireless-connected-080">
+]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px" sugar:attach-points="970,850"><g display="block" id="network-wireless-connected-080">
 	<path d="M46.375,27.498c0,10.494-8.507,19.002-19,19.002s-19-8.508-19-19.002   c0-10.49,8.507-18.998,19-18.998S46.375,17.003,46.375,27.498z" display="inline" fill="&stroke_color;"/>
 	<g display="inline">
 		<g>

--- a/icons/scalable/device/network-wireless-connected-100.icon
+++ b/icons/scalable/device/network-wireless-connected-100.icon
@@ -1,2 +1,0 @@
-[Icon Data]
-AttachPoints=970,850

--- a/icons/scalable/device/network-wireless-connected-100.svg
+++ b/icons/scalable/device/network-wireless-connected-100.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
 	<!ENTITY stroke_color "#010101">
 	<!ENTITY fill_color "#ffffff">
-]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="network-wireless-connected-100">
+]><svg enable-background="new 0 0 55 55" height="55px" id="Layer_1" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px" sugar:attach-points="970,850"><g display="block" id="network-wireless-connected-100">
 	<g>
 		<g>
 			<defs>


### PR DESCRIPTION
Requires https://github.com/sugarlabs/sugar-toolkit-gtk3/pull/199 in the toolkit.

> `gtk_icon_info_get_attach_points` has been deprecated since version 3.14 and should not be used in newly-written code.
>
> Attachment points are deprecated

From https://developer.gnome.org/gtk3/stable/GtkIconTheme.html#gtk-icon-info-get-attach-points

This adds the attachment point metadata into the SVG files.  Attachment points
are a feature that we need in sugar, so we can not drop it as GTK does.