### PR TITLE
Show background color in toggle and radio buttons in toolbar with Gtk…

### DIFF
--- a/gtk3/theme/gtk-widgets.css.em
+++ b/gtk3/theme/gtk-widgets.css.em
@@ -601,7 +601,11 @@ SugarPaletteWindowWidget GtkToolButton .button:prelight {
 }
 
 .toolbar SugarRadioToolButton *:active,
-SugarPaletteWindowWidget SugarRadioToolButton *:active {
+SugarPaletteWindowWidget SugarRadioToolButton *:active,
+.toolbar SugarRadioToolButton *:checked,
+SugarPaletteWindowWidget SugarRadioToolButton *:checked,
+.toolbar SugarToggleToolButton *:checked,
+SugarPaletteWindowWidget SugarToggleToolButton *:checked {
     background-color: @button_grey;
     border-radius: $(toolbutton_padding)px;
 }


### PR DESCRIPTION
… >= 3.14

As noted here [1], Gtk introduced a new state "checked"
to show when a radio and check buttons are pressed.
This solve the issue showed in Fedora 21 where the radio and toggle
buttons in the toolbar didn't show the state.

[1] https://git.gnome.org/browse/gtk+/commit/?id=2c65e259448a9ec261f0dcf420662300786204c2