### PR TITLE
Gtk 3 14 regrssions

### DIFF
--- a/gtk3/theme/gtk-widgets.css.em
+++ b/gtk3/theme/gtk-widgets.css.em
@@ -731,14 +731,20 @@ SugarPaletteWindowWidget .check {
 
 .radio:active,
 .radio row:selected:active,
-.radio row:selected:focused:active {
+.radio row:selected:focused:active,
+.radio:checked,
+.radio row:selected:checked,
+.radio row:selected:focused:checked {
     background-image: url("assets/radio-active.svg");
     -gtk-icon-source: url("assets/radio-active.svg");
 }
 
 .radio:active:selected,
 .radio:selected row:selected:active,
-.radio:selected row:selected:focused:active {
+.radio:selected row:selected:focused:active,
+.radio:checked:selected,
+.radio:selected row:selected:checked,
+.radio:selected row:selected:focused:checked {
     background-image: url("assets/radio-active-selected.svg");
     -gtk-icon-source: url("assets/radio-active-selected.svg");
 }
@@ -760,14 +766,20 @@ SugarPaletteWindowWidget .check {
 
 .check:active,
 .check row:selected:active,
-.check row:selected:focused:active {
+.check row:selected:focused:active,
+.check:checked,
+.check row:selected:checked,
+.check row:selected:focused:checked {
     background-image: url("assets/checkbox-checked.svg");
     -gtk-icon-source: url("assets/checkbox-checked.svg");
 }
 
 .check:active:selected,
 .check:selected row:selected:active,
-.check:selected row:selected:focused:active {
+.check:selected row:selected:focused:active,
+.check:checked:selected,
+.check:selected row:selected:checked,
+.check:selected row:selected:focused:checked {
     background-image: url("assets/checkbox-checked-selected.svg");
     -gtk-icon-source: url("assets/checkbox-checked-selected.svg");
 }

--- a/gtk3/theme/gtk-widgets.css.em
+++ b/gtk3/theme/gtk-widgets.css.em
@@ -716,6 +716,9 @@ SugarPaletteWindowWidget .check {
 .radio row:selected,
 .radio row:selected:focused {
     background-image: url("assets/radio.svg");
+    /* Gtk 3.14+ expect these to be included in icon theme however we want to
+       override that */
+    -gtk-icon-source: url("assets/radio.svg");
     background-color: alpha(@theme_base_color, 0.0);
 }
 
@@ -723,44 +726,50 @@ SugarPaletteWindowWidget .check {
 .radio:selected row:selected,
 .radio:selected row:selected:focused {
     background-image: url("assets/radio-selected.svg");
+    -gtk-icon-source: url("assets/radio-selected.svg");
 }
 
 .radio:active,
 .radio row:selected:active,
 .radio row:selected:focused:active {
     background-image: url("assets/radio-active.svg");
+    -gtk-icon-source: url("assets/radio-active.svg");
 }
 
 .radio:active:selected,
 .radio:selected row:selected:active,
 .radio:selected row:selected:focused:active {
     background-image: url("assets/radio-active-selected.svg");
+    -gtk-icon-source: url("assets/radio-active-selected.svg");
 }
 
 .check,
 .check row:selected,
 .check row:selected:focused {
     background-image: url("assets/checkbox-unchecked.svg");
+    -gtk-icon-source: url("assets/checkbox-unchecked.svg");
     background-color: alpha(@theme_base_color, 0.0);
-    border: 1px solid @black;
 }
 
 .check:selected,
 .check:selected row:selected,
 .check:selected row:selected:focused {
     background-image: url("assets/checkbox-unchecked-selected.svg");
+    -gtk-icon-source: url("assets/checkbox-unchecked-selected.svg");
 }
 
 .check:active,
 .check row:selected:active,
 .check row:selected:focused:active {
     background-image: url("assets/checkbox-checked.svg");
+    -gtk-icon-source: url("assets/checkbox-checked.svg");
 }
 
 .check:active:selected,
 .check:selected row:selected:active,
 .check:selected row:selected:focused:active {
     background-image: url("assets/checkbox-checked-selected.svg");
+    -gtk-icon-source: url("assets/checkbox-checked-selected.svg");
 }
 
 /* Tool items */


### PR DESCRIPTION
I do not know if there are any related tickets.

```
commit 562d650949129d894f6a769f9f0d8a5ca1c449db
Author: Sam Parkinson <sam.parkinson3@gmail.com>
Date:   Fri May 15 20:17:03 2015 +1000

    Gtk 3.14 regressions: checked state for checkboxes and radiobuttons
    
    Checkable things use the :checked state instead of the :active state now.
    
    This commit adapts the sugar theme to use this for the checkboxes and
    radiobuttons, while keeping the old :active states for older versions.

commit 8088214ed9b4c2c67b097ab104f4abaa8af916f4
Author: Sam Parkinson <sam.parkinson3@gmail.com>
Date:   Fri May 15 20:08:14 2015 +1000

    Gtk 3.14 regressions: use sugar assets for checkboxes and radio buttons
    
    Changes in Gtk 3.14 [1] expect assets for checkboxes and radio buttons to be
    included in the icon theme, not as the css background.  This commit uses the
    `-gtk-icon-source` property to tell gtk to use our pre-exsisting assets.
    
    This also removes the needs for hacks such as adding a border in css, namely
    commit 27fac30cb028a7461f40da6765db13c017ad6f13.
    
    How to test:
    
    1.  Open "gtk3-widget-factory" or the network control panel
    2.  Notice how the checkboxes have the simple sugar tick, not the complex
        GNOME tick.
    
    [1] https://mail.gnome.org/archives/gtk-devel-list/2014-May/msg00020.html
```