### PR TITLE
Basic GTK Popover styling - makes GTK+ Inspector more usable

### DIFF
--- a/gtk3/theme/gtk-widgets.css.em
+++ b/gtk3/theme/gtk-widgets.css.em
@@ -408,7 +408,8 @@ SugarHTray * , SugarVTray * { background-color: @toolbar_grey;}
 
 /* Menus and palettes */
 
-SugarPaletteWindowWidget {
+SugarPaletteWindowWidget,
+GtkPopover {
     border-width: $(thickness)px;
     border-color: @button_grey;
     border-style: solid;


### PR DESCRIPTION
There does not seem to be a way to change the styling of the arrow in F21 (without a theme engine).