### PR TITLE
Fix SugarKeepIcon Background

### DIFF
--- a/gtk3/theme/gtk-widgets.css.em
+++ b/gtk3/theme/gtk-widgets.css.em
@@ -816,6 +816,7 @@ SugarKeepIcon.button {
     border-radius: $(4 * thickness)px;
     border-width: 2px;
     border-style: solid;
+    background-color: transparent;
 }
 
 SugarCanvasIcon:prelight,


### PR DESCRIPTION
The background for the SugarKeepIcon has recently [1] been changed to
black/grey.  This is not what we want - so we must over ride this.

Before:

![screenshot from 2015-05-16 19 08 37](https://cloud.githubusercontent.com/assets/6022042/7665538/fa271132-fbfe-11e4-9ae4-a21d887d6183.png)

(No - my mouse is not over the SugarKeepIcon!)


After:

![screenshot from 2015-05-16 19 07 06](https://cloud.githubusercontent.com/assets/6022042/7665537/c5ef8048-fbfe-11e4-8059-9146b3fac117.png)


[1] Probably f001eaee65cd99ece69922c690f37be9438bb6b4 - didn't test