### PR TITLE
Fix active activity highlight in the frame

### DIFF
--- a/gtk3/theme/gtk-widgets.css.em
+++ b/gtk3/theme/gtk-widgets.css.em
@@ -597,15 +597,19 @@ SugarPaletteWindowWidget GtkToolButton .button:prelight {
 }
 
 .toolbar GtkToolButton .button:prelight,
+.toolbar GtkToolButton .button:prelight GtkBox,
 SugarPaletteWindowWidget GtkToolButton .button:prelight {
     background-color: @black;
 }
 
 .toolbar SugarRadioToolButton *:active,
 SugarPaletteWindowWidget SugarRadioToolButton *:active,
+.toolbar SugarRadioToolButton *:active GtkBox,
 .toolbar SugarRadioToolButton *:checked,
+.toolbar SugarRadioToolButton *:checked GtkBox,
 SugarPaletteWindowWidget SugarRadioToolButton *:checked,
 .toolbar SugarToggleToolButton *:checked,
+.toolbar SugarToggleToolButton *:checked GtkBox,
 SugarPaletteWindowWidget SugarToggleToolButton *:checked {
     background-color: @button_grey;
     border-radius: $(toolbutton_padding)px;


### PR DESCRIPTION
Make sure the active activity is highlighted fully - not just with a
border.  This is done by changing the background of the GtkBox that
the icons reside inside.