### PR TITLE
Fix style in Radio and Check for old states names

### DIFF
--- a/gtk3/theme/gtk-widgets.css.em
+++ b/gtk3/theme/gtk-widgets.css.em
@@ -736,7 +736,11 @@ SugarPaletteWindowWidget .check {
 
 .radio:active,
 .radio row:selected:active,
-.radio row:selected:focused:active,
+.radio row:selected:focused:active {
+    background-image: url("assets/radio-active.svg");
+    -gtk-icon-source: url("assets/radio-active.svg");
+}
+
 .radio:checked,
 .radio row:selected:checked,
 .radio row:selected:focused:checked {
@@ -746,7 +750,11 @@ SugarPaletteWindowWidget .check {
 
 .radio:active:selected,
 .radio:selected row:selected:active,
-.radio:selected row:selected:focused:active,
+.radio:selected row:selected:focused:active {
+    background-image: url("assets/radio-active-selected.svg");
+    -gtk-icon-source: url("assets/radio-active-selected.svg");
+}
+
 .radio:checked:selected,
 .radio:selected row:selected:checked,
 .radio:selected row:selected:focused:checked {
@@ -771,7 +779,11 @@ SugarPaletteWindowWidget .check {
 
 .check:active,
 .check row:selected:active,
-.check row:selected:focused:active,
+.check row:selected:focused:active {
+    background-image: url("assets/checkbox-checked.svg");
+    -gtk-icon-source: url("assets/checkbox-checked.svg");
+}
+
 .check:checked,
 .check row:selected:checked,
 .check row:selected:focused:checked {
@@ -781,7 +793,11 @@ SugarPaletteWindowWidget .check {
 
 .check:active:selected,
 .check:selected row:selected:active,
-.check:selected row:selected:focused:active,
+.check:selected row:selected:focused:active {
+    background-image: url("assets/checkbox-checked-selected.svg");
+    -gtk-icon-source: url("assets/checkbox-checked-selected.svg");
+}
+
 .check:checked:selected,
 .check:selected row:selected:checked,
 .check:selected row:selected:focused:checked {


### PR DESCRIPTION
Radio buttons and Check boxes were not displating the selected
images on Ubuntu 14.04 LTS.

This patch separates both styles for the older active state and
the newer checked state, to make sure both use the images.

Signed-off-by: Martin Abente Lahaye <tch@sugarlabs.org>