### PR TITLE
Don't change background color on active button at prelight

### DIFF
--- a/gtk3/theme/gtk-widgets.css.em
+++ b/gtk3/theme/gtk-widgets.css.em
@@ -615,6 +615,20 @@ SugarPaletteWindowWidget SugarToggleToolButton *:checked {
     border-radius: $(toolbutton_padding)px;
 }
 
+.toolbar SugarRadioToolButton *:checked:prelight,
+.toolbar SugarRadioToolButton *:checked:prelight GtkBox,
+SugarPaletteWindowWidget SugarRadioToolButton *:checked:prelight,
+.toolbar SugarToggleToolButton *:checked:prelight,
+.toolbar SugarToggleToolButton *:checked:prelight GtkBox,
+SugarPaletteWindowWidget SugarToggleToolButton *:checked:prelight {
+    background-color: @button_grey;
+}
+
+SugarPaletteWindowWidget SugarRadioToolButton *:checked:prelight,
+SugarPaletteWindowWidget SugarToggleToolButton *:checked:prelight {
+    border-color: @button_grey;
+}
+
 SugarPaletteWindowWidget GtkToolButton .button:active {
     background-color: @button_grey;
 }


### PR DESCRIPTION
When the user move the mouse over a active toolbar button
with grey background, the background should not change to black.
This is visible on systems with Gtk >=  3.14, in the top right
buttons in the Home View in Sugar.