### PR TITLE
Fix treeview background, fixes #4855

### DIFF
--- a/gtk3/theme/gtk-widgets.css.em
+++ b/gtk3/theme/gtk-widgets.css.em
@@ -1,5 +1,10 @@
 ${
 import math
+from gi.repository import Gtk
+
+gtk_major = int(Gtk.get_major_version())
+gtk_minor = int(Gtk.get_minor_version())
+treeview_pseudo_element = gtk_major >= 3 and gtk_minor > 8
 
 def my_floor(num):
     return int(math.floor(num))
@@ -221,10 +226,14 @@ column-header .button:hover:active {
     border-width: 0px;
 }
 
-GtkTreeView row:nth-child(even) {
+$[if treeview_pseudo_element] GtkTreeView row:even
+$[else] GtkTreeView row:nth-child(even)
+$[end if] {
     background-color: @row_even;
 }
-GtkTreeView row:nth-child(odd) {
+$[if treeview_pseudo_element] GtkTreeView row:odd
+$[else] GtkTreeView row:nth-child(odd)
+$[end if] {
     background-color: @row_odd;
 }
 


### PR DESCRIPTION
Replaces #63 

This also therefore fixes #4857

This also introduces the requirement of using gi.repository.Gtk
during build time of sugar artwork.