### PR TITLE
Fix TreeView rows colors

### DIFF
--- a/gtk3/theme/gtk-widgets.css.em
+++ b/gtk3/theme/gtk-widgets.css.em
@@ -221,6 +221,13 @@ column-header .button:hover:active {
     border-width: 0px;
 }
 
+GtkTreeView row:even {
+    background-color: @row_even;
+}
+GtkTreeView row:odd {
+    background-color: @row_odd;
+}
+
 GtkTreeView row:nth-child(even) {
     background-color: @row_even;
 }


### PR DESCRIPTION
Add parallel rules for fixing rows colors alternation in TreeViews,
e.g, in Log activity side list, for Gtk 3.16+.

Note that parser will skip the previous rules if he fails to parse
the new rules. Therefore, when adding "parallel" rules for newer
gtk versions, these rules must be added separately. Otherwise, it
will break the previous rules for older gtk versions.

Signed-off-by: Martin Abente Lahaye <tch@sugarlabs.org>