### PR TITLE
Properly set background color for sub toolbars, fixes #4884

### DIFF
--- a/gtk3/theme/gtk-widgets.css.em
+++ b/gtk3/theme/gtk-widgets.css.em
@@ -554,10 +554,11 @@ SugarPaletteWindowWidget GtkProgressBar.trough {
 
 /* Tool buttons */
 
+SugarToolbarBox,
 .toolbar {
-padding: 0px;
-background-color: @toolbar_grey;
-color: @white;
+    padding: 0px;
+    background-color: @toolbar_grey;
+    color: @white;
 }
 
 .toolbar .button,


### PR DESCRIPTION
The .toolbar selector only applies to the toolbar content zone,
so by including the container the margin can also be styled with
the correct background color (specifically for gtk 3.17+).

Requires:  https://github.com/sugarlabs/sugar-toolkit-gtk3/pull/255
Fixes:  https://bugs.sugarlabs.org/ticket/4884