### PR TITLE
Use appropriate treeview row styling for Gtk+ version, fixes #4855

### DIFF
--- a/gtk3/theme/gtk-widgets.css.em
+++ b/gtk3/theme/gtk-widgets.css.em
@@ -1,5 +1,15 @@
 ${
+import os
 import math
+from gi.repository import Gtk
+
+if 'GTK_MAJOR' in os.environ:
+    gtk_major = int(os.environ['GTK_MAJOR'])
+    gtk_minor = int(os.environ['GTK_MINOR'])
+else:
+    gtk_major = int(Gtk.get_major_version())
+    gtk_minor = int(Gtk.get_minor_version())
+treeview_pseudo_element = gtk_major >= 3 and gtk_minor > 8
 
 def my_floor(num):
     return int(math.floor(num))
@@ -221,17 +231,15 @@ column-header .button:hover:active {
     border-width: 0px;
 }
 
-GtkTreeView row:even {
+$[if treeview_pseudo_element] GtkTreeView row:even
+$[else] GtkTreeView row:nth-child(even)
+$[end if] {
     background-color: @row_even;
-}
-GtkTreeView row:odd {
-    background-color: @row_odd;
 }
 
-GtkTreeView row:nth-child(even) {
-    background-color: @row_even;
-}
-GtkTreeView row:nth-child(odd) {
+$[if treeview_pseudo_element] GtkTreeView row:odd
+$[else] GtkTreeView row:nth-child(odd)
+$[end if] {
     background-color: @row_odd;
 }
 


### PR DESCRIPTION
The older Gtk+ treeview css make the treeviews background single
colored on newer Gtk+.

The Gtk+ version is discovered through the GTK_MAJOR and GTK_MINOR
environment variables, which can be set by the packager.  It then
attepts to import Gtk if they are not found.

Ticket <https://bugs.sugarlabs.org/ticket/4855>