### PR TITLE
Use appropriate treeview row styling for Gtk+ version, fixes #4855

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,9 @@ PKG_CHECK_MODULES(ENGINE3, gtk+-3.0 >= 3.0 gobject-2.0 >= 2.0 cairo >= 0.1.1)
 GTK_VERSION=`$PKG_CONFIG --variable=gtk_binary_version gtk+-2.0`
 AC_SUBST(GTK_VERSION)
 
+GTK3_VERSION=`$PKG_CONFIG --modversion gtk+-3.0`
+AC_SUBST(GTK3_VERSION)
+
 ICON_NAMING_UTILS_REQUIRED=0.8.2
 
 AC_MSG_CHECKING([icon-naming-utils >= $ICON_NAMING_UTILS_REQUIRED])

--- a/gtk3/theme/Makefile.am
+++ b/gtk3/theme/Makefile.am
@@ -1,11 +1,13 @@
 SUBDIRS = assets
 
 gtk-widgets-72.css: gtk-widgets.css.em
-	$(srcdir)/em.py -p $$ -D scaling=\'72\' $(srcdir)/gtk-widgets.css.em > \
+	$(srcdir)/em.py -p $$ -D scaling=\'72\' -D gtk=\'$(GTK3_VERSION)\' \
+		$(srcdir)/gtk-widgets.css.em > \
 		$(top_builddir)/gtk3/theme/gtk-widgets-72.css
 
 gtk-widgets-100.css: gtk-widgets.css.em
-	$(srcdir)/em.py -p $$ -D scaling=\'100\' $(srcdir)/gtk-widgets.css.em > \
+	$(srcdir)/em.py -p $$ -D scaling=\'100\' -D gtk=\'$(GTK3_VERSION)\' \
+		$(srcdir)/gtk-widgets.css.em > \
 		$(top_builddir)/gtk3/theme/gtk-widgets-100.css
 
 settings-72.ini: settings.ini.em

--- a/gtk3/theme/gtk-widgets.css.em
+++ b/gtk3/theme/gtk-widgets.css.em
@@ -1,5 +1,9 @@
 ${
+import os
 import math
+
+gtk_major, gtk_minor, gtk_patch = map(int, gtk.split('.'))
+treeview_pseudo_element = gtk_major >= 3 and gtk_minor >= 16
 
 def my_floor(num):
     return int(math.floor(num))
@@ -221,17 +225,15 @@ column-header .button:hover:active {
     border-width: 0px;
 }
 
-GtkTreeView row:even {
+$[if treeview_pseudo_element] GtkTreeView row:even
+$[else] GtkTreeView row:nth-child(even)
+$[end if] {
     background-color: @row_even;
-}
-GtkTreeView row:odd {
-    background-color: @row_odd;
 }
 
-GtkTreeView row:nth-child(even) {
-    background-color: @row_even;
-}
-GtkTreeView row:nth-child(odd) {
+$[if treeview_pseudo_element] GtkTreeView row:odd
+$[else] GtkTreeView row:nth-child(odd)
+$[end if] {
     background-color: @row_odd;
 }
 


### PR DESCRIPTION
The older Gtk+ treeview css make the treeviews background single
colored on newer Gtk+.  This patch discovers the Gtk+ version
through pkg-config as to introduce no new deps.

Ticket <https://bugs.sugarlabs.org/ticket/4855>

Replaces  #74 