### PR TITLE
Don't set background to black when long-pressing buttons.

### DIFF
--- a/gtk3/theme/gtk-widgets.css.em
+++ b/gtk3/theme/gtk-widgets.css.em
@@ -591,9 +591,9 @@ SugarPaletteWindowWidget GtkToolButton .button:prelight {
     background-clip: padding-box;
 }
 
-.toolbar GtkToolButton .button:prelight,
-.toolbar GtkToolButton .button:prelight GtkBox,
-SugarPaletteWindowWidget GtkToolButton .button:prelight {
+.toolbar GtkToolButton .button:prelight:not(:active):not(:checked),
+.toolbar GtkToolButton .button:prelight:not(:active):not(:checked) GtkBox,
+SugarPaletteWindowWidget GtkToolButton .button:prelight:not(:active):not(:checked) {
     background-color: @black;
 }
 


### PR DESCRIPTION
Before Gtk 3.18 the buttons were fully grey when they
were clicked (long press).
With gtk 3.18 it shows a black square, rounded with a
grey border.

This is a regression, so this restore the previous
behaviour

Also tested on XO-4 (with old Gtk version) and this patch doesn't broke the normal behaviour