### PR TITLE
Explicitly style ToolButton insensitive state, fixes #4901

### DIFF
--- a/gtk3/theme/gtk-widgets.css.em
+++ b/gtk3/theme/gtk-widgets.css.em
@@ -49,6 +49,8 @@ thickness = my_ceil(line_width)
 icon_small = icon_base * 3
 icon_large = icon_base * 5
 
+disabled_opacity = 1.0/3
+
 }
 
 * {
@@ -581,6 +583,11 @@ SugarPaletteWindowWidget GtkToolButton .button {
     background-color: transparent;
     border-radius: $(toolbutton_padding)px;
     padding: $(toolbutton_padding)px;
+}
+
+GtkToolButton .button:insensitive,
+SugarRadioToolButton .button:insensitive {
+    opacity: $(disabled_opacity);
 }
 
 .toolbar GtkToolButton .button,


### PR DESCRIPTION
The insensitive state of ToolButtons was implicitly styled, however
newer Gtk+ versions have broken this behaviour.

Ticket  <https://bugs.sugarlabs.org/ticket/4901>