### PR TITLE
Use style props to set odd and even colours

### DIFF
--- a/gtk3/theme/gtk-widgets.css.em
+++ b/gtk3/theme/gtk-widgets.css.em
@@ -63,6 +63,8 @@ disabled_opacity = 0.5
     /* we have to disable focus border for GtkTreeView, see #1261 */
     -GtkTreeView-interior-focus: 1;
     -GtkTreeView-focus-line-width: 0;
+    -GtkTreeView-odd-row-color: @row_odd;
+    -GtkTreeView-even-row-color: @row_even;
 
     -GtkTextView-interior-focus: 1;
 


### PR DESCRIPTION
Gtk+ has removed the .row regions upstream [1] and we can migrate
to the style props instead.

NOTE:  this doesn't actually fix the bug for me, so this is just
       to remind me to test whose fault it is at a later date

NOTE:  I used the find function, however I can't actually see an implementation of the odd/even coloring in gtktreeview.c.  I'm running 3.19.1, which that commit is included in, and I don't see it working :crying_cat_face:.  I think this might be the last we see of row colouring without persuing things upstream.

    #include <gtkcssrant.h>

[1]  https://github.com/GNOME/gtk/commit/b65f400d565a3d30a9cd8b686296176f00abefee