### PR TITLE
Migrate entry styles to "css nodes"

### DIFF
--- a/gtk3/theme/gtk-widgets.css.em
+++ b/gtk3/theme/gtk-widgets.css.em
@@ -488,6 +488,7 @@ SugarPaletteWindow SugarGroupBox *:insensitive {
     background-color: @button_grey;
 }
 
+.menuitem separator,
 .menuitem.separator {
     padding: 0;
 }
@@ -560,6 +561,7 @@ SugarPaletteWindowWidget GtkProgressBar.trough {
 
 /* Separators */
 
+separator,
 .separator {
     border-style: solid;
     border-color: @button_grey;

--- a/gtk3/theme/gtk-widgets.css.em
+++ b/gtk3/theme/gtk-widgets.css.em
@@ -176,6 +176,7 @@ GtkLabel, GtkLabel:insensitive {
 
 /* Spin buttons */
 
+spinbutton button,
 .spinbutton.button {
     border-radius: 0px;
     border-width: 0px;
@@ -183,6 +184,7 @@ GtkLabel, GtkLabel:insensitive {
     background-color: @button_grey;
 }
 
+spinbutton button:last-child,
 .spinbutton.button:last-child {
     border-radius: 0px $(2*subcell_size)px $(2*subcell_size)px 0px;
     border-width: 0px 0px 0px $(thickness)px;
@@ -191,10 +193,12 @@ GtkLabel, GtkLabel:insensitive {
 }
 
 
+spinbutton button:active,
 .spinbutton.button:active {
     background-color: @black;
 }
 
+spinbutton button:insensitive,
 .spinbutton.button:insensitive {
     background-color: @selection_grey;
 }
@@ -239,6 +243,7 @@ $[end if] {
     background-color: @row_odd;
 }
 
+entry,
 .entry {
     border-radius: $(2 * subcell_size)px;
     border-width: $(thickness)px;
@@ -251,25 +256,26 @@ $[end if] {
     padding: $(2 * max(my_ceil((3*subcell_size - font_height - entry_ythickness*2)/2.0),0))px $(2 * max(subcell_size - entry_xthickness, 0))px $(2 * max(my_floor((3*subcell_size - font_height - entry_ythickness*2)/2.0), 0))px $(2 * max(subcell_size - entry_xthickness, 0))px;
 }
 
+entry progress,
 .entry.progressbar {
     border-radius: $(2 * subcell_size)px;
     border-width: $(thickness)px;
     background-color: @selection_grey;
 }
 
+entry:focused,
 .entry:focused {
     background-color: @white;
 }
 
+.toolbar entry:focused,
 .toolbar .entry:focused {
     border-color: @white;
 }
 
+entry:insensitive,
 .entry:insensitive {
     background-color: @button_grey;
-}
-
-.entry:insensitive {
     border-color: @button_grey;
 }
 
@@ -278,6 +284,8 @@ $[end if] {
     color: @black;
 }
 
+entry:selected,
+entry:selected:focused,
 .entry:selected,
 .entry:selected:focused,
 .view:selected:focused {
@@ -285,6 +293,8 @@ $[end if] {
     color: @black;
 }
 
+entry:selected,
+entry:selected:focused
 .entry:selected,
 .entry:selected:focused {
     border-color: @selection_grey;


### PR DESCRIPTION
Upstream, gtk has changed to using "css nodes" [1].  This is a
first pass conversion that preserves most of the styles.

[1]  https://github.com/GNOME/gtk/commit/bb7d7851ac5cecf960a7ed69af06b2dd0a29484b

Gtk3 version:  gtk3-3.19.1-1.fc24.x86_64

**Before**

[![https://gyazo.com/36a77ce4eb1f60f05c56e0685add4d4d](https://i.gyazo.com/36a77ce4eb1f60f05c56e0685add4d4d.png)](https://gyazo.com/36a77ce4eb1f60f05c56e0685add4d4d)

**After**

![](https://i.gyazo.com/335a73c90b96c89cc3f5868af4057957.png)