### PR TITLE
Gtk3 19 regressions

### DIFF
--- a/gtk3/theme/gtk-widgets.css.em
+++ b/gtk3/theme/gtk-widgets.css.em
@@ -272,7 +272,9 @@ entry:focused,
 }
 
 .toolbar entry:focused,
-.toolbar .entry:focused {
+.toolbar .entry:focused,
+toolbar entry:focused,
+toolbar .entry:focused {
     border-color: @white;
 }
 
@@ -574,6 +576,7 @@ separator,
 /* Tool buttons */
 
 SugarToolbarBox,
+toolbar,
 .toolbar {
     padding: 0px;
     background-color: @toolbar_grey;
@@ -581,18 +584,22 @@ SugarToolbarBox,
 }
 
 .toolbar .button,
+toolbar .button,
 SugarPaletteWindowWidget SugarRadioToolButton .button {
     border-color: transparent;
     border-radius: 0px;
     border-style: none;
 }
 
-.toolbar .button #gtk-toolbar-arrow {
+.toolbar .button #gtk-toolbar-arrow,
+toolbar .button #gtk-toolbar-arrow {
     padding: 0 $(subcell_size + default_padding)px;
 }
 
 .toolbar GtkToolButton .button,
 .toolbar SugarRadioToolButton .button,
+toolbar GtkToolButton .button,
+toolbar SugarRadioToolButton .button,
 SugarPaletteWindowWidget SugarRadioToolButton .button,
 SugarPaletteWindowWidget GtkToolButton .button {
     background-color: transparent;
@@ -606,6 +613,7 @@ SugarRadioToolButton .button:insensitive {
 }
 
 .toolbar GtkToolButton .button,
+toolbar GtkToolButton .button,
 SugarPaletteWindowWidget GtkToolButton .button:prelight {
     padding: $(toolbutton_padding - default_padding)px;
     border-width: $(default_padding)px;
@@ -615,18 +623,26 @@ SugarPaletteWindowWidget GtkToolButton .button:prelight {
 
 .toolbar GtkToolButton .button:prelight:not(:active):not(:checked),
 .toolbar GtkToolButton .button:prelight:not(:active):not(:checked) GtkBox,
+toolbar GtkToolButton .button:prelight:not(:active):not(:checked),
+toolbar GtkToolButton .button:prelight:not(:active):not(:checked) GtkBox,
 SugarPaletteWindowWidget GtkToolButton .button:prelight:not(:active):not(:checked) {
     background-color: @black;
 }
 
 .toolbar SugarRadioToolButton *:active,
+toolbar SugarRadioToolButton *:active,
 SugarPaletteWindowWidget SugarRadioToolButton *:active,
 .toolbar SugarRadioToolButton *:active GtkBox,
 .toolbar SugarRadioToolButton *:checked,
 .toolbar SugarRadioToolButton *:checked GtkBox,
+toolbar SugarRadioToolButton *:active GtkBox,
+toolbar SugarRadioToolButton *:checked,
+toolbar SugarRadioToolButton *:checked GtkBox,
 SugarPaletteWindowWidget SugarRadioToolButton *:checked,
 .toolbar SugarToggleToolButton *:checked,
 .toolbar SugarToggleToolButton *:checked GtkBox,
+toolbar SugarToggleToolButton *:checked,
+toolbar SugarToggleToolButton *:checked GtkBox,
 SugarPaletteWindowWidget SugarToggleToolButton *:checked {
     background-color: @button_grey;
     border-radius: $(toolbutton_padding)px;
@@ -634,9 +650,13 @@ SugarPaletteWindowWidget SugarToggleToolButton *:checked {
 
 .toolbar SugarRadioToolButton *:checked:prelight,
 .toolbar SugarRadioToolButton *:checked:prelight GtkBox,
+toolbar SugarRadioToolButton *:checked:prelight,
+toolbar SugarRadioToolButton *:checked:prelight GtkBox,
 SugarPaletteWindowWidget SugarRadioToolButton *:checked:prelight,
 .toolbar SugarToggleToolButton *:checked:prelight,
 .toolbar SugarToggleToolButton *:checked:prelight GtkBox,
+toolbar SugarToggleToolButton *:checked:prelight,
+toolbar SugarToggleToolButton *:checked:prelight GtkBox,
 SugarPaletteWindowWidget SugarToggleToolButton *:checked:prelight {
     background-color: @button_grey;
 }
@@ -650,7 +670,8 @@ SugarPaletteWindowWidget GtkToolButton .button:active {
     background-color: @button_grey;
 }
 
-.toolbar GtkToolButton .button:active {
+.toolbar GtkToolButton .button:active,
+toolbar GtkToolButton .button:active {
     background-color: @button_grey;
     border-radius: $(toolbutton_padding)px;
 }
@@ -742,7 +763,10 @@ GtkCheckButton:prelight {
     background-color: alpha(@theme_base_color, 0.0);
 }
 
-.toolbar GtkCheckButton,.toolbar .check,
+.toolbar GtkCheckButton,
+.toolbar .check,
+toolbar GtkCheckButton,
+toolbar .check,
 SugarPaletteWindowWidget .check {
     color: @theme_base_color;
     border: 1px solid @theme_base_color;

--- a/gtk3/theme/gtk-widgets.css.em
+++ b/gtk3/theme/gtk-widgets.css.em
@@ -4,6 +4,9 @@ import math
 
 gtk_major, gtk_minor, gtk_patch = map(int, gtk.split('.'))
 treeview_pseudo_element = gtk_major >= 3 and gtk_minor >= 16
+# On new gtk versions, setting the radio button icon via the background
+# image prop causes the RadioToolButtons to inherit that background
+radio_bg_image = not (gtk_major >= 3 and gtk_minor > 18)
 
 def my_floor(num):
     return int(math.floor(num))
@@ -748,7 +751,7 @@ SugarPaletteWindowWidget .check {
 .radio,
 .radio row:selected,
 .radio row:selected:focused {
-    background-image: url("assets/radio.svg");
+    $[if radio_bg_image] background-image: url("assets/radio.svg"); $[end if]
     /* Gtk 3.14+ expect these to be included in icon theme however we want to
        override that */
     -gtk-icon-source: url("assets/radio.svg");
@@ -758,42 +761,42 @@ SugarPaletteWindowWidget .check {
 .radio:selected,
 .radio:selected row:selected,
 .radio:selected row:selected:focused {
-    background-image: url("assets/radio-selected.svg");
+    $[if radio_bg_image] background-image: url("assets/radio-selected.svg"); $[end if]
     -gtk-icon-source: url("assets/radio-selected.svg");
 }
 
 .radio:active,
 .radio row:selected:active,
 .radio row:selected:focused:active {
-    background-image: url("assets/radio-active.svg");
+    $[if radio_bg_image] background-image: url("assets/radio-active.svg"); $[end if]
     -gtk-icon-source: url("assets/radio-active.svg");
 }
 
 .radio:checked,
 .radio row:selected:checked,
 .radio row:selected:focused:checked {
-    background-image: url("assets/radio-active.svg");
+    $[if radio_bg_image] background-image: url("assets/radio-active.svg"); $[end if]
     -gtk-icon-source: url("assets/radio-active.svg");
 }
 
 .radio:active:selected,
 .radio:selected row:selected:active,
 .radio:selected row:selected:focused:active {
-    background-image: url("assets/radio-active-selected.svg");
+    $[if radio_bg_image] background-image: url("assets/radio-active-selected.svg"); $[end if]
     -gtk-icon-source: url("assets/radio-active-selected.svg");
 }
 
 .radio:checked:selected,
 .radio:selected row:selected:checked,
 .radio:selected row:selected:focused:checked {
-    background-image: url("assets/radio-active-selected.svg");
+    $[if radio_bg_image] background-image: url("assets/radio-active-selected.svg"); $[end if]
     -gtk-icon-source: url("assets/radio-active-selected.svg");
 }
 
 .check,
 .check row:selected,
 .check row:selected:focused {
-    background-image: url("assets/checkbox-unchecked.svg");
+    $[if radio_bg_image] background-image: url("assets/checkbox-unchecked.svg"); $[end if]
     -gtk-icon-source: url("assets/checkbox-unchecked.svg");
     background-color: alpha(@theme_base_color, 0.0);
 }
@@ -801,35 +804,35 @@ SugarPaletteWindowWidget .check {
 .check:selected,
 .check:selected row:selected,
 .check:selected row:selected:focused {
-    background-image: url("assets/checkbox-unchecked-selected.svg");
+    $[if radio_bg_image] background-image: url("assets/checkbox-unchecked-selected.svg"); $[end if]
     -gtk-icon-source: url("assets/checkbox-unchecked-selected.svg");
 }
 
 .check:active,
 .check row:selected:active,
 .check row:selected:focused:active {
-    background-image: url("assets/checkbox-checked.svg");
+    $[if radio_bg_image] background-image: url("assets/checkbox-checked.svg"); $[end if]
     -gtk-icon-source: url("assets/checkbox-checked.svg");
 }
 
 .check:checked,
 .check row:selected:checked,
 .check row:selected:focused:checked {
-    background-image: url("assets/checkbox-checked.svg");
+    $[if radio_bg_image] background-image: url("assets/checkbox-checked.svg"); $[end if]
     -gtk-icon-source: url("assets/checkbox-checked.svg");
 }
 
 .check:active:selected,
 .check:selected row:selected:active,
 .check:selected row:selected:focused:active {
-    background-image: url("assets/checkbox-checked-selected.svg");
+    $[if radio_bg_image] background-image: url("assets/checkbox-checked-selected.svg"); $[end if]
     -gtk-icon-source: url("assets/checkbox-checked-selected.svg");
 }
 
 .check:checked:selected,
 .check:selected row:selected:checked,
 .check:selected row:selected:focused:checked {
-    background-image: url("assets/checkbox-checked-selected.svg");
+    $[if radio_bg_image] background-image: url("assets/checkbox-checked-selected.svg"); $[end if]
     -gtk-icon-source: url("assets/checkbox-checked-selected.svg");
 }
 


### PR DESCRIPTION
2 commits to fix some of the broken things in sugar.  Please see the commit log for details.

Neither have been tested against older gtk versions.  Any tests are appreciated.  There should be no visual change after applying the patch.

I have not created a bug to represent the issues that I'm seeing on fedora rawhide, although many appear to be due to Gtk+ issues that also effect gnome.  I'll keep a list here for the time being:

* [ ] No padding in the toolbars.  This also happens in other places, eg. GNOME's text selection touch popover (which sugar should add css for, but that's another discussion)
* [x] Toolbar colours broken
* [ ] Scales are inivisble
* [ ] Progressbars are also invisible
* [ ] All palettes (very recently) lost their borders
* [ ] Lots of random things got borders.  Eg. every spacer in the toolbar.  However, that is also in GNOME (eg. menus)
* [x] The home view selector has radio buttons tiled as the background