### PR TITLE
Support <ctrl>Tab and <ctrl><shift>Tab shortcuts on all notebooks

### DIFF
--- a/gtk3/theme/Makefile.am
+++ b/gtk3/theme/Makefile.am
@@ -38,6 +38,8 @@ install-data-local: $(GEN_FILES)
 		$(DESTDIR)$(datadir)/themes/sugar-72/gtk-3.0/settings.ini
 	$(INSTALL_DATA) $(srcdir)/gtk.css \
 		$(DESTDIR)$(datadir)/themes/sugar-72/gtk-3.0/gtk.css
+	$(INSTALL_DATA) $(srcdir)/gtk-keys.css \
+		$(DESTDIR)$(datadir)/themes/sugar-72/gtk-3.0/gtk-keys.css
 	$(mkinstalldirs) $(DESTDIR)$(datadir)/themes/sugar-100/gtk-3.0
 	$(INSTALL_DATA) $(top_builddir)/gtk3/theme/gtk-widgets-100.css \
 		$(DESTDIR)$(datadir)/themes/sugar-100/gtk-3.0/gtk-widgets.css
@@ -45,10 +47,16 @@ install-data-local: $(GEN_FILES)
 		$(DESTDIR)$(datadir)/themes/sugar-100/gtk-3.0/settings.ini
 	$(INSTALL_DATA) $(srcdir)/gtk.css \
 		$(DESTDIR)$(datadir)/themes/sugar-100/gtk-3.0/gtk.css
+	$(INSTALL_DATA) $(srcdir)/gtk-keys.css \
+		$(DESTDIR)$(datadir)/themes/sugar-100/gtk-3.0/gtk-keys.css
 	$(INSTALL_DATA) $(srcdir)/gtk.css \
 		$(DESTDIR)$(datadir)/themes/sugar-72/gtk-3.20/gtk.css
+	$(INSTALL_DATA) $(srcdir)/gtk-keys.css \
+		$(DESTDIR)$(datadir)/themes/sugar-72/gtk-3.20/gtk-keys.css
 	$(INSTALL_DATA) $(srcdir)/gtk.css \
 		$(DESTDIR)$(datadir)/themes/sugar-100/gtk-3.20/gtk.css
+	$(INSTALL_DATA) $(srcdir)/gtk-keys.css \
+		$(DESTDIR)$(datadir)/themes/sugar-100/gtk-3.20/gtk-keys.css
 	cp -r $(DESTDIR)$(datadir)/themes/sugar-100/gtk-3.0/assets \
 	    $(DESTDIR)$(datadir)/themes/sugar-100/gtk-3.20/assets
 	cp -r $(DESTDIR)$(datadir)/themes/sugar-72/gtk-3.0/assets \

--- a/gtk3/theme/gtk-keys.css
+++ b/gtk3/theme/gtk-keys.css
@@ -1,0 +1,8 @@
+@binding-set sugar-notebook-keys {
+    bind "<ctrl>Tab" { "change-current-page" (1) }
+    bind "<ctrl><shift>Tab" { "change-current-page" (-1) }
+}
+
+notebook, GtkNotebook {
+    -gtk-binding-set sugar-notebook-keys;
+}

--- a/gtk3/theme/gtk.css
+++ b/gtk3/theme/gtk.css
@@ -26,4 +26,4 @@
 @define-color theme_base_color @base_color;
 
 @import url("gtk-widgets.css");
-
+@import url("gtk-keys.css");


### PR DESCRIPTION
Many activities, for example Pippy [1], add these shortcuts
in Python code.  Coding all of these is a waste of time - just
adding more copy and paste code, although it can make some
good beginner GCI tasks.

Humor aside, this patch adds the basic infrastructure for our Gtk+
"key theme".  By using a key theme, we can change the shortcut for
every Gtk3 notebook (tab widget) on the computer.

[1] https://github.com/sugarlabs/Pippy/blob/ec11963a443bb64b0042ae67175ecf9450490137/notebook.py#L248