### PR TITLE
Add favourite locked emblem

### DIFF
--- a/icons/scalable/emblems/Makefile.am
+++ b/icons/scalable/emblems/Makefile.am
@@ -8,6 +8,7 @@ icon_DATA =			\
 	emblem-downloads.svg	\
 	emblem-favorite.svg	\
 	emblem-locked.svg	\
+	emblem-favorite-locked.svg	\
 	emblem-notification.svg	\
 	emblem-outofrange.svg	\
 	emblem-question.svg	\

--- a/icons/scalable/emblems/emblem-favorite-locked.svg
+++ b/icons/scalable/emblems/emblem-favorite-locked.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
+	<!ENTITY stroke_color "#666666">
+	<!ENTITY fill_color "#ffffff">
+]><svg enable-background="new 0 0 55 55" height="55px" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="emblem-favorite-locked">
+	<polygon fill="&fill_color;" points="27.5,5.149 34.76,19.865 51,22.224    39.251,33.68 42.025,49.852 27.5,42.215 12.976,49.852 15.75,33.68 4,22.224 20.237,19.865  " stroke="&stroke_color;" stroke-linecap="round" stroke-width="3"/>
+	<rect fill="&stroke_color;" height="14.06" width="17.824" x="18.589" y="24.725"/>
+	<path d="M22.515,24.725v-3.637c0-2.692,2.18-4.869,4.868-4.869     c2.688,0,4.867,2.181,4.867,4.869v3.637" fill="none" stroke="&stroke_color;" stroke-width="3.5"/>
+</g></svg>


### PR DESCRIPTION
Add an emblem to be used as an icon badge on the neighbourhood view for wireless networks that are both favourite and locked.  Used by https://github.com/sugarlabs/sugar/pull/704.