### PR TITLE
Fix control panel search result highlight

### DIFF
--- a/gtk3/theme/gtk-widgets.css.em
+++ b/gtk3/theme/gtk-widgets.css.em
@@ -4,6 +4,7 @@ import math
 
 gtk_major, gtk_minor, gtk_patch = map(int, gtk.split('.'))
 treeview_pseudo_element = gtk_major >= 3 and gtk_minor >= 16
+opacity_exists = gtk_major >= 3 and gtk_minor >= 8
 
 def my_floor(num):
     return int(math.floor(num))
@@ -599,7 +600,9 @@ SugarPaletteWindowWidget GtkToolButton .button {
 
 GtkToolButton .button:insensitive,
 SugarRadioToolButton .button:insensitive {
+$[if opacity_exists]
     opacity: $(disabled_opacity);
+$[end if]
 }
 
 .toolbar GtkToolButton .button,

--- a/gtk3/theme/gtk-widgets.css.em
+++ b/gtk3/theme/gtk-widgets.css.em
@@ -119,6 +119,9 @@ disabled_opacity = 0.5
 
 *:insensitive {
     color: @button_grey;
+$[if opacity_exists]
+    opacity: 0.75;
+$[end if]
 }
 
 /* Backgrounds and windows */


### PR DESCRIPTION
**Suppress opacity error on Gtk+ 3.6.**

On Fedora 18 with Gtk+ 3.6, since 5a7cc8b7 an error is logged because `opacity` is not known; it was introduced in Gtk+ 3.8.  Condtionally refer to it instead.

**Fix control panel search result highlighting.**

On Ubuntu 16.04 with Gtk+ 3.18 the control panel search does not highlight; the section icons are insensitive and cannot be clicked, but they have no change in appearance.  Add an opacity declaration for insensitive widgets.

_Question for reviewers; how would the selector be made more specific?_
