### PR TITLE
Fix ColorToolButton normal and prelight background

### DIFF
--- a/gtk3/theme/gtk-widgets.css.em
+++ b/gtk3/theme/gtk-widgets.css.em
@@ -616,9 +616,14 @@ SugarPaletteWindowWidget GtkToolButton .button:prelight {
     background-clip: padding-box;
 }
 
+.toolbar SugarColorToolButton .button {
+    background-color: @toolbar_grey;
+}
+
 .toolbar GtkToolButton .button:prelight:not(:active):not(:checked),
 .toolbar GtkToolButton .button:prelight:not(:active):not(:checked) GtkBox,
-SugarPaletteWindowWidget GtkToolButton .button:prelight:not(:active):not(:checked) {
+SugarPaletteWindowWidget GtkToolButton .button:prelight:not(:active):not(:checked),
+.toolbar SugarColorToolButton .button:prelight {
     background-color: @black;
 }
 


### PR DESCRIPTION
Paint and Physics activities did show incorrect button background, because `ColorToolButton` has somewhat unusual parentage.

Screenshots with problem https://github.com/sugarlabs/physics/pull/23 .

Fixes https://github.com/sugarlabs/physics/issues/24 .
