### PR TITLE
Set margin to subcell size for separators

### DIFF
--- a/gtk3/theme/3.20/gtk-widgets.css.em
+++ b/gtk3/theme/3.20/gtk-widgets.css.em
@@ -524,8 +524,7 @@ separator {
 
 toolbar separator {
     border-left: $(thickness)px solid @button_grey;
-    margin-left: $(subcell_size)px;
-    margin-right: $(subcell_size)px;
+    margin: $(subcell_size)px;
     background: transparent;
 }
 


### PR DESCRIPTION
This restores how separators used to work in older
versions of Gtk/Sugar.

That means: the separator now shows as a vertical line
but it no longer uses the whole toolbar size.

Please see: http://people.sugarlabs.org/ignacio/sugar_separator.png

This may only fix Gtk >= 3.20 at the moment. Not tested older versions.