### PR TITLE
Don't override existing document-open icon

### DIFF
--- a/icons/scalable/actions/Makefile.am
+++ b/icons/scalable/actions/Makefile.am
@@ -134,7 +134,6 @@ EXTRA_DIST = $(icon_DATA)
 # install aliases for icons, and the use the icon-naming-utils to install
 # further aliases for compatibility with gtk stock icon names.
 install-data-local: install-iconDATA
-	ln -sf activity-start.svg $(DESTDIR)$(icondir)/document-open.svg
 	ln -sf activity-stop.svg $(DESTDIR)$(icondir)/application-exit.svg
 	ln -sf dialog-ok.svg $(DESTDIR)$(icondir)/dialog-apply.svg
 	ln -sf dialog-ok.svg $(DESTDIR)$(icondir)/gtk-ok.svg


### PR DESCRIPTION
Remove this old override on a existing icon. Otherwise the document-open icon is shown as actvity-start.

Looking at b8a1f426 it is clear that this override was added before we provided our own version of this icon.