### PR TITLE
configure.ac: Add --without-gtk2 option

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,1 +1,5 @@
-SUBDIRS = cursor icons gtk gtk3
+SUBDIRS = cursor icons gtk3
+
+if WITH_GTK2
+    SUBDIRS += gtk
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -26,20 +26,37 @@ if test -z "$EMPY"; then
     AC_MSG_ERROR([empy is required])
 fi
 
-PKG_CHECK_MODULES(GTK2, gtk+-2.0 >= 2.16.0,,
-	          AC_MSG_ERROR([GTK+-2.0 is required to compile sugar-artwork]))
-
 PKG_CHECK_MODULES(GTK3, gtk+-3.0 >= 3.0.0,,
 	          AC_MSG_ERROR([GTK+-3.0 is required to compile sugar-artwork]))
 
-PKG_CHECK_MODULES(ENGINE, gtk+-2.0 >= 2.16 gobject-2.0 >= 2.0 cairo >= 0.1.1)
 PKG_CHECK_MODULES(ENGINE3, gtk+-3.0 >= 3.0 gobject-2.0 >= 2.0 cairo >= 0.1.1)
-
-GTK_VERSION=`$PKG_CONFIG --variable=gtk_binary_version gtk+-2.0`
-AC_SUBST(GTK_VERSION)
 
 GTK3_VERSION=`$PKG_CONFIG --modversion gtk+-3.0`
 AC_SUBST(GTK3_VERSION)
+
+AC_ARG_WITH([gtk2],
+  [AS_HELP_STRING([--without-gtk2], [Omit GTK2 dependency (default=no)])],
+  [with_gtk2=$withval],
+  [with_gtk2=yes])
+
+if test "x${with_gtk2}" = "xyes"; then
+
+    PKG_CHECK_MODULES(GTK2, gtk+-2.0 >= 2.16.0,,
+	              AC_MSG_ERROR([GTK+-2.0 is required to compile sugar-artwork]))
+
+    PKG_CHECK_MODULES(ENGINE, gtk+-2.0 >= 2.16 gobject-2.0 >= 2.0 cairo >= 0.1.1)
+
+    GTK_VERSION=`$PKG_CONFIG --variable=gtk_binary_version gtk+-2.0`
+    AC_SUBST(GTK_VERSION)
+
+    AC_CONFIG_FILES([
+        gtk/Makefile
+        gtk/engine/Makefile
+        gtk/theme/Makefile
+    ])
+fi
+
+AM_CONDITIONAL([WITH_GTK2], [test "x${with_gtk2}" = "xyes"])
 
 ICON_NAMING_UTILS_REQUIRED=0.8.2
 
@@ -72,9 +89,6 @@ icons/scalable/device/Makefile
 icons/scalable/emblems/Makefile
 icons/scalable/mimetypes/Makefile
 icons/scalable/status/Makefile
-gtk/Makefile
-gtk/engine/Makefile
-gtk/theme/Makefile
 gtk3/Makefile
 gtk3/theme/Makefile
 gtk3/theme/3.20/Makefile


### PR DESCRIPTION
We don't need nor require GTK2 in some scenarios, e.g. when porting Activities to flatpak. I can imagine this will be useful for  building artwork package in modern distributions as well.