### PR TITLE
Depend on empy python module

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,10 +21,7 @@ if test -z "$XCURSORGEN"; then
 fi
 
 AM_PATH_PYTHON
-AC_PATH_PROGS([EMPY], [empy empy3])
-if test -z "$EMPY"; then
-    AC_MSG_ERROR([empy is required])
-fi
+AS_IF([$PYTHON -m em >/dev/null 2>&1], AC_MSG_RESULT([empy found]), AC_MSG_ERROR([empy not found]))
 
 PKG_CHECK_MODULES(GTK3, gtk+-3.0 >= 3.0.0,,
 	          AC_MSG_ERROR([GTK+-3.0 is required to compile sugar-artwork]))

--- a/gtk/theme/Makefile.am
+++ b/gtk/theme/Makefile.am
@@ -1,10 +1,10 @@
 sugar-72.gtkrc: gtkrc.em
-	$(PYTHON) - -p $$ -D scaling=\'72\' $(srcdir)/gtkrc.em > \
-		$(top_builddir)/gtk/theme/sugar-72.gtkrc < $(EMPY)
+	$(PYTHON) -m em -p $$ -D scaling=\'72\' $(srcdir)/gtkrc.em > \
+		$(top_builddir)/gtk/theme/sugar-72.gtkrc
 
 sugar-100.gtkrc: gtkrc.em
-	$(PYTHON) - -p $$ -D scaling=\'100\' $(srcdir)/gtkrc.em > \
-		$(top_builddir)/gtk/theme/sugar-100.gtkrc < $(EMPY)
+	$(PYTHON) -m em -p $$ -D scaling=\'100\' $(srcdir)/gtkrc.em > \
+		$(top_builddir)/gtk/theme/sugar-100.gtkrc
 
 clean:
 	$(RM) sugar-72.gtkrc

--- a/gtk3/theme/3.20/Makefile.am
+++ b/gtk3/theme/3.20/Makefile.am
@@ -1,12 +1,12 @@
 gtk-widgets-72.css: gtk-widgets.css.em
-	$(PYTHON) - -p $$ -D scaling=\'72\' -D gtk=\'$(GTK3_VERSION)\' \
+	$(PYTHON) -m em -p $$ -D scaling=\'72\' -D gtk=\'$(GTK3_VERSION)\' \
 		$(srcdir)/gtk-widgets.css.em > \
-		$(top_builddir)/gtk3/theme/3.20/gtk-widgets-72.css < $(EMPY)
+		$(top_builddir)/gtk3/theme/3.20/gtk-widgets-72.css 
 
 gtk-widgets-100.css: gtk-widgets.css.em
-	$(PYTHON) - -p $$ -D scaling=\'100\' -D gtk=\'$(GTK3_VERSION)\' \
+	$(PYTHON) -m em -p $$ -D scaling=\'100\' -D gtk=\'$(GTK3_VERSION)\' \
 		$(srcdir)/gtk-widgets.css.em > \
-		$(top_builddir)/gtk3/theme/3.20/gtk-widgets-100.css < $(EMPY)
+		$(top_builddir)/gtk3/theme/3.20/gtk-widgets-100.css
 
 clean:
 	$(RM) gtk-widgets-100.css

--- a/gtk3/theme/Makefile.am
+++ b/gtk3/theme/Makefile.am
@@ -1,22 +1,22 @@
 SUBDIRS = assets 3.20
 
 gtk-widgets-72.css: gtk-widgets.css.em
-	$(PYTHON) - -p $$ -D scaling=\'72\' -D gtk=\'$(GTK3_VERSION)\' \
+	$(PYTHON) -m em -p $$ -D scaling=\'72\' -D gtk=\'$(GTK3_VERSION)\' \
 		$(srcdir)/gtk-widgets.css.em > \
-		$(top_builddir)/gtk3/theme/gtk-widgets-72.css < $(EMPY)
+		$(top_builddir)/gtk3/theme/gtk-widgets-72.css
 
 gtk-widgets-100.css: gtk-widgets.css.em
-	$(PYTHON) - -p $$ -D scaling=\'100\' -D gtk=\'$(GTK3_VERSION)\' \
+	$(PYTHON) -m em -p $$ -D scaling=\'100\' -D gtk=\'$(GTK3_VERSION)\' \
 		$(srcdir)/gtk-widgets.css.em > \
-		$(top_builddir)/gtk3/theme/gtk-widgets-100.css < $(EMPY)
+		$(top_builddir)/gtk3/theme/gtk-widgets-100.css
 
 settings-72.ini: settings.ini.em
-	$(PYTHON) - -p $$ -D scaling=\'72\' $(srcdir)/settings.ini.em > \
-		$(top_builddir)/gtk3/theme/settings-72.ini < $(EMPY)
+	$(PYTHON) -m em -p $$ -D scaling=\'72\' $(srcdir)/settings.ini.em > \
+		$(top_builddir)/gtk3/theme/settings-72.ini
 
 settings-100.ini: settings.ini.em
-	$(PYTHON) - -p $$ -D scaling=\'100\' $(srcdir)/settings.ini.em > \
-		$(top_builddir)/gtk3/theme/settings-100.ini < $(EMPY)
+	$(PYTHON) -m em -p $$ -D scaling=\'100\' $(srcdir)/settings.ini.em > \
+		$(top_builddir)/gtk3/theme/settings-100.ini 
 
 clean:
 	$(RM) gtk-widgets-100.css


### PR DESCRIPTION
Fix makefile dependency on `/usr/bin/empy` for Linux distributions 
which do not package a empy binary executable.
