### PR TITLE
Set the color of the text caret

### DIFF
--- a/gtk3/theme/3.20/gtk-widgets.css.em
+++ b/gtk3/theme/3.20/gtk-widgets.css.em
@@ -155,6 +155,7 @@ textview text {  /* Setting a textview to background white makes it black,
     padding: 0px;
     background: @white;
     color: @black;
+    caret-color: @black;
 }
 
 treeview header button,


### PR DESCRIPTION
sugar3.activity.widgets.DescriptionItem textview cursor wasn't visible, and this sets the caret color of the textview to black assuming it was a different color, this ensures it's black.

@quozl kindly review, related to [sugarlabs/sugar-toolklit-gtk3#471](https://github.com/sugarlabs/sugar-toolkit-gtk3/pull/471)