### PR TITLE
Port to Empy4.2

### DIFF
--- a/gtk/theme/gtkrc.em
+++ b/gtk/theme/gtkrc.em
@@ -691,7 +691,7 @@ style "menuitem"
     text[ACTIVE]      = $white
 
     xthickness = $subcell_size
-    ythickness = $((subcell_size * 3 - font_height) / 2)
+    ythickness = @((subcell_size * 3 - font_height) / 2)
 }
 
 style "checkmenuitem"
@@ -699,7 +699,7 @@ style "checkmenuitem"
     GtkCheckMenuItem::indicator-size = $radio_size
     GtkMenuItem::toggle-spacing = $(subcell_size * 2 / 3)
 
-    ythickness = $((subcell_size * 3 - max(font_height, subcell_size * 2 / 3)) / 2)
+    ythickness = @((subcell_size * 3 - max(font_height, subcell_size * 2 / 3)) / 2)
 
     # This is only there because of bug #382646 ...
     base[NORMAL]      = $white

--- a/gtk3/theme/3.20/gtk-widgets.css.em
+++ b/gtk3/theme/3.20/gtk-widgets.css.em
@@ -422,7 +422,7 @@ menu {
 }
 
 menuitem {
-    padding: $(subcell_size)px $((subcell_size * 3 - font_height) / 2)px;
+    padding: $(subcell_size)px @((subcell_size * 3 - font_height) / 2)px;
 }
 
 menuitem:hover,

--- a/gtk3/theme/gtk-widgets.css.em
+++ b/gtk3/theme/gtk-widgets.css.em
@@ -489,7 +489,7 @@ SugarPaletteWindow SugarGroupBox *:insensitive {
 }
 
 .menuitem {
-    padding: $(subcell_size)px $((subcell_size * 3 - font_height) / 2)px;
+    padding: $(subcell_size)px @((subcell_size * 3 - font_height) / 2)px;
 }
 
 .menuitem:prelight, .menuitem:hover {


### PR DESCRIPTION
Package fails to build in fedora with error;
```bash
python3 -m em -p $ -D scaling=\'72\' -D gtk=\'3.24.43\' \
	./gtk-widgets.css.em > \
	../../../gtk3/theme/3.20/gtk-widgets-72.css
./gtk-widgets.css.em:426:29: error: ParseError: unknown markup sequence: `$((`; extension markup `@((...))` invoked with no installed extension
```
this fixes that, this is the [fedora build](https://koji.fedoraproject.org/koji/taskinfo?taskID=122555243) with my changes.

@quozl @AJAY172003 kindly test and review.

