### PR TITLE
Port to Empy-4.2

### DIFF
--- a/gtk/theme/gtkrc.em
+++ b/gtk/theme/gtkrc.em
@@ -691,7 +691,7 @@ style "menuitem"
     text[ACTIVE]      = $white
 
     xthickness = $subcell_size
-    ythickness = $((subcell_size * 3 - font_height) / 2)
+    ythickness = @((subcell_size * 3 - font_height) / 2)
 }
 
 style "checkmenuitem"
@@ -699,7 +699,7 @@ style "checkmenuitem"
     GtkCheckMenuItem::indicator-size = $radio_size
     GtkMenuItem::toggle-spacing = $(subcell_size * 2 / 3)
 
-    ythickness = $((subcell_size * 3 - max(font_height, subcell_size * 2 / 3)) / 2)
+    ythickness = @((subcell_size * 3 - max(font_height, subcell_size * 2 / 3)) / 2)
 
     # This is only there because of bug #382646 ...
     base[NORMAL]      = $white

--- a/gtk3/theme/3.20/gtk-widgets.css.em
+++ b/gtk3/theme/3.20/gtk-widgets.css.em
@@ -423,7 +423,7 @@ menu {
 }
 
 menuitem {
-    padding: $(subcell_size)px $((subcell_size * 3 - font_height) / 2)px;
+    padding: $(subcell_size)px @((subcell_size * 3 - font_height) / 2)px;
 }
 
 menuitem:hover,

--- a/gtk3/theme/gtk-widgets.css.em
+++ b/gtk3/theme/gtk-widgets.css.em
@@ -489,7 +489,7 @@ SugarPaletteWindow SugarGroupBox *:insensitive {
 }
 
 .menuitem {
-    padding: $(subcell_size)px $((subcell_size * 3 - font_height) / 2)px;
+    padding: $(subcell_size)px @((subcell_size * 3 - font_height) / 2)px;
 }
 
 .menuitem:prelight, .menuitem:hover {


### PR DESCRIPTION
python3 -m em -p $ -D scaling=\'72\' ./gtkrc.em > \
	../../gtk/theme/sugar-72.gtkrc

./gtkrc.em:693:31: error: ParseError: unknown markup sequence: `$((`; extension markup `@((...))` invoked with no installed extension
<root>:1:1: from this context
make[3]: *** [Makefile:465: sugar-72.gtkrc] Error 1
make[3]: Leaving directory '/home/ajay/sugar-artwork/gtk/theme'
make[2]: *** [Makefile:358: install-am] Error 2
make[2]: Leaving directory '/home/ajay/sugar-artwork/gtk/theme'
make[1]: *** [Makefile:370: install-recursive] Error 1
make[1]: Leaving directory '/home/ajay/sugar-artwork/gtk'
make: *** [Makefile:418: install-recursive] Error 1

Port successfully to empy 4.3 by fixing abive issues for ubuntu build
@chimosky please test it for fedora as i did change in 1 more file.
