### PR TITLE
Fix port to Empy-4.2

### DIFF
--- a/gtk/theme/gtkrc.em
+++ b/gtk/theme/gtkrc.em
@@ -691,7 +691,7 @@ style "menuitem"
     text[ACTIVE]      = $white
 
     xthickness = $subcell_size
-    ythickness = @((subcell_size * 3 - font_height) / 2)
+    ythickness = $( (subcell_size * 3 - font_height) / 2)
 }
 
 style "checkmenuitem"
@@ -699,7 +699,7 @@ style "checkmenuitem"
     GtkCheckMenuItem::indicator-size = $radio_size
     GtkMenuItem::toggle-spacing = $(subcell_size * 2 / 3)
 
-    ythickness = @((subcell_size * 3 - max(font_height, subcell_size * 2 / 3)) / 2)
+    ythickness = $( (subcell_size * 3 - max(font_height, subcell_size * 2 / 3)) / 2)
 
     # This is only there because of bug #382646 ...
     base[NORMAL]      = $white

--- a/gtk3/theme/3.20/gtk-widgets.css.em
+++ b/gtk3/theme/3.20/gtk-widgets.css.em
@@ -423,7 +423,7 @@ menu {
 }
 
 menuitem {
-    padding: $(subcell_size)px @((subcell_size * 3 - font_height) / 2)px;
+    padding: $(subcell_size)px $( (subcell_size * 3 - font_height) / 2)px;
 }
 
 menuitem:hover,

--- a/gtk3/theme/gtk-widgets.css.em
+++ b/gtk3/theme/gtk-widgets.css.em
@@ -489,7 +489,7 @@ SugarPaletteWindow SugarGroupBox *:insensitive {
 }
 
 .menuitem {
-    padding: $(subcell_size)px @((subcell_size * 3 - font_height) / 2)px;
+    padding: $(subcell_size)px $( (subcell_size * 3 - font_height) / 2)px;
 }
 
 .menuitem:prelight, .menuitem:hover {


### PR DESCRIPTION
The PR #123 replaced the $ sign with @, but it caused that the values were not substitued, which procedured an invalid value. Revert it, and add a space between brackets to fix compilation with Empy-4.2.