### PR TITLE
Port theme to GTK4

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = cursor icons gtk3
+SUBDIRS = cursor icons gtk3 gtk4
 
 if WITH_GTK2
     SUBDIRS += gtk

--- a/configure.ac
+++ b/configure.ac
@@ -97,5 +97,8 @@ gtk3/theme/3.20/Makefile
 gtk3/theme/assets/Makefile
 gtk3/theme/assets/72/Makefile
 gtk3/theme/assets/100/Makefile
+gtk4/Makefile
+gtk4/theme/Makefile
+gtk4/theme/assets/Makefile
 ])
 AC_OUTPUT

--- a/gtk4/Makefile.am
+++ b/gtk4/Makefile.am
@@ -1,0 +1,1 @@
+SUBDIRS = theme

--- a/gtk4/theme/Makefile.am
+++ b/gtk4/theme/Makefile.am
@@ -1,0 +1,15 @@
+SUBDIRS = assets
+
+install-data-local:
+	$(mkinstalldirs) $(DESTDIR)$(datadir)/themes/sugar-72/gtk-4.0
+	$(INSTALL_DATA) $(srcdir)/gtk.css \
+		$(DESTDIR)$(datadir)/themes/sugar-72/gtk-4.0/gtk.css
+	$(mkinstalldirs) $(DESTDIR)$(datadir)/themes/sugar-100/gtk-4.0
+	$(INSTALL_DATA) $(srcdir)/gtk.css \
+		$(DESTDIR)$(datadir)/themes/sugar-100/gtk-4.0/gtk.css
+
+uninstall-local:
+	rm -f $(DESTDIR)$(datadir)/themes/sugar-72/gtk-4.0/gtk.css
+	rm -f $(DESTDIR)$(datadir)/themes/sugar-100/gtk-4.0/gtk.css
+
+EXTRA_DIST = gtk.css

--- a/gtk4/theme/assets/Makefile.am
+++ b/gtk4/theme/assets/Makefile.am
@@ -1,0 +1,18 @@
+assets =			\
+	checkbox-unchecked.svg		\
+	checkbox-unchecked-selected.svg	\
+	checkbox-checked.svg		\
+	checkbox-checked-selected.svg	\
+	radio.svg			\
+	radio-selected.svg		\
+	radio-active.svg		\
+	radio-active-selected.svg	\
+	scale-slider.svg		\
+	scale-slider-active.svg		\
+	viewsource-imageBox-bg.svg
+
+sugar72dir = $(datadir)/themes/sugar-72/gtk-4.0/assets
+sugar100dir = $(datadir)/themes/sugar-100/gtk-4.0/assets
+
+dist_sugar72_DATA = $(assets)
+dist_sugar100_DATA = $(assets)

--- a/gtk4/theme/assets/checkbox-checked-selected.svg
+++ b/gtk4/theme/assets/checkbox-checked-selected.svg
@@ -1,0 +1,8 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+  <!ENTITY fill_color "#E5E5E5">
+  <!ENTITY stroke_color "#010101">
+]>
+<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18">
+    <rect width="16" height="16" x="1" y="1" color="&stroke_color;" fill="&fill_color;" stroke="#808080" stroke-width="2" stroke-linecap="round" overflow="visible" enable-background="accumulate"/>
+    <path d="M4.115 8.915l3.314 3.317 6.456-6.463" stroke="&stroke_color;" stroke-width="2" stroke-linecap="round" fill="none"/>
+</svg>

--- a/gtk4/theme/assets/checkbox-checked.svg
+++ b/gtk4/theme/assets/checkbox-checked.svg
@@ -1,0 +1,8 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+  <!ENTITY fill_color "#FFFFFF">
+  <!ENTITY stroke_color "#010101">
+]>
+<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18">
+    <rect width="16" height="16" x="1" y="1" color="&stroke_color;" fill="&fill_color;" stroke="#808080" stroke-width="2" stroke-linecap="round" overflow="visible" enable-background="accumulate"/>
+    <path d="M4.115 8.915l3.314 3.317 6.456-6.463" stroke="&stroke_color;" stroke-width="2" stroke-linecap="round" fill="none"/>
+</svg>

--- a/gtk4/theme/assets/checkbox-unchecked-selected.svg
+++ b/gtk4/theme/assets/checkbox-unchecked-selected.svg
@@ -1,0 +1,6 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+  <!ENTITY fill_color "#E5E5E5">
+]>
+<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18">
+    <rect width="16" height="16" x="1" y="1" color="#000" stroke="#808080" stroke-width="2" stroke-linecap="round" overflow="visible" enable-background="accumulate" fill="&fill_color;"/>
+</svg>

--- a/gtk4/theme/assets/checkbox-unchecked.svg
+++ b/gtk4/theme/assets/checkbox-unchecked.svg
@@ -1,0 +1,6 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+  <!ENTITY fill_color "#FFFFFF">
+]>
+<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18">
+    <rect width="16" height="16" x="1" y="1" color="#000" stroke="#808080" stroke-width="2" stroke-linecap="round" overflow="visible" enable-background="accumulate" fill="none"/>
+</svg>

--- a/gtk4/theme/assets/radio-active-selected.svg
+++ b/gtk4/theme/assets/radio-active-selected.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+  <!ENTITY fill_color "#E5E5E5">
+  <!ENTITY stroke_color "#010101">
+]>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="18"
+   height="18"
+   id="svg27352">
+  <path
+     d="m -12.928177,-10.441989 a 11.20442,11.20442 0 1 1 -22.40884,0 11.20442,11.20442 0 1 1 22.40884,0 z"
+     transform="matrix(0.75863092,0,0,0.75863092,27.307382,16.921967)"
+     id="path4787"
+     style="color:#010101;fill:&fill_color;;fill-opacity:1;fill-rule:nonzero;stroke:#808080;stroke-width:1.31816399;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m -13.966103,0.94915253 a 11.79661,11.79661 0 1 1 -23.593219,0 11.79661,11.79661 0 1 1 23.593219,0 z"
+     transform="matrix(0.33908047,0,0,0.33908047,17.735633,8.6781609)"
+     id="path4634"
+     style="color:#010101;fill:&stroke_color;;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.14473462;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+</svg>

--- a/gtk4/theme/assets/radio-active.svg
+++ b/gtk4/theme/assets/radio-active.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+  <!ENTITY fill_color "#FFFFFF">
+  <!ENTITY stroke_color "#010101">
+]>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="18"
+   height="18"
+   id="svg27352">
+  <path
+     d="m -12.928177,-10.441989 a 11.20442,11.20442 0 1 1 -22.40884,0 11.20442,11.20442 0 1 1 22.40884,0 z"
+     transform="matrix(0.75863092,0,0,0.75863092,27.307382,16.921967)"
+     id="path4787"
+     style="color:#010101;fill:&fill_color;;fill-opacity:1;fill-rule:nonzero;stroke:#808080;stroke-width:1.31816399;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m -13.966103,0.94915253 a 11.79661,11.79661 0 1 1 -23.593219,0 11.79661,11.79661 0 1 1 23.593219,0 z"
+     transform="matrix(0.33908047,0,0,0.33908047,17.735633,8.6781609)"
+     id="path4634"
+     style="color:#010101;fill:&stroke_color;;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.14473462;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+</svg>

--- a/gtk4/theme/assets/radio-selected.svg
+++ b/gtk4/theme/assets/radio-selected.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+  <!ENTITY fill_color "#E5E5E5">
+  <!ENTITY stroke_color "#010101">
+]>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="18"
+   height="18"
+   id="svg27352">
+  <path
+     d="m -12.928177,-10.441989 a 11.20442,11.20442 0 1 1 -22.40884,0 11.20442,11.20442 0 1 1 22.40884,0 z"
+     transform="matrix(0.75863092,0,0,0.75863092,27.307382,16.921967)"
+     id="path4787"
+     style="color:#010101;fill:&fill_color;;fill-opacity:1;fill-rule:nonzero;stroke:#808080;stroke-width:1.31816399;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+</svg>

--- a/gtk4/theme/assets/radio.svg
+++ b/gtk4/theme/assets/radio.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+  <!ENTITY fill_color "#E5E5E5">
+  <!ENTITY stroke_color "#010101">
+]>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="18"
+   height="18"
+   id="svg27352">
+  <path
+     d="m -12.928177,-10.441989 a 11.20442,11.20442 0 1 1 -22.40884,0 11.20442,11.20442 0 1 1 22.40884,0 z"
+     transform="matrix(0.75863092,0,0,0.75863092,27.307382,16.921967)"
+     id="path4787"
+     style="color:#010101;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#808080;stroke-width:1.31816399;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+</svg>

--- a/gtk4/theme/assets/scale-slider-active.svg
+++ b/gtk4/theme/assets/scale-slider-active.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+  <!ENTITY fill_color "#FFFFFF">
+  <!ENTITY stroke_color "#010101">
+]>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="24"
+   height="24"
+   id="svg5980">
+  <path
+     d="m -13.966103,0.94915253 a 11.79661,11.79661 0 1 1 -23.593219,0 11.79661,11.79661 0 1 1 23.593219,0 z"
+     transform="matrix(0.93247503,0,0,0.93247504,36.023086,11.114939)"
+     id="path4632"
+     style="color:#010101;fill:&fill_color;;fill-opacity:1;fill-rule:nonzero;stroke:#808080;stroke-width:2.14473462;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m -13.966103,0.94915253 a 11.79661,11.79661 0 1 1 -23.593219,0 11.79661,11.79661 0 1 1 23.593219,0 z"
+     transform="matrix(0.5086207,0,0,0.5086207,25.103449,11.517241)"
+     id="path4634"
+     style="color:#010101;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.14473462;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+</svg>

--- a/gtk4/theme/assets/scale-slider.svg
+++ b/gtk4/theme/assets/scale-slider.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+  <!ENTITY fill_color "#E5E5E5">
+  <!ENTITY stroke_color "#010101">
+]>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="24"
+   height="24"
+   id="svg5980">
+  <path
+     d="m -13.966103,0.94915253 a 11.79661,11.79661 0 1 1 -23.593219,0 11.79661,11.79661 0 1 1 23.593219,0 z"
+     transform="matrix(0.93247503,0,0,0.93247504,36.023086,11.114939)"
+     id="path4632"
+     style="color:#010101;fill:&fill_color;;fill-opacity:1;fill-rule:nonzero;stroke:#808080;stroke-width:2.14473462;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m -13.966103,0.94915253 a 11.79661,11.79661 0 1 1 -23.593219,0 11.79661,11.79661 0 1 1 23.593219,0 z"
+     transform="matrix(0.5086207,0,0,0.5086207,25.103449,11.517241)"
+     id="path4634"
+     style="color:#010101;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.14473462;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+</svg>

--- a/gtk4/theme/assets/viewsource-imageBox-bg.svg
+++ b/gtk4/theme/assets/viewsource-imageBox-bg.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 20010904//EN"
+  "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+<svg width="10" height="10">
+    <rect x="0" y="0" width="5" height="5" fill="#e5e5e5"/>
+    <rect x="5" y="0" width="5" height="5" fill="white"/>
+    <rect x="0" y="5" width="5" height="5" fill="white"/>
+    <rect x="5" y="5" width="5" height="5" fill="#e5e5e5"/>
+</svg>

--- a/gtk4/theme/gtk.css
+++ b/gtk4/theme/gtk.css
@@ -1,0 +1,1454 @@
+/* 1. COLOR PALETTE  (from gtk.css and gtkrc.em) */
+
+@define-color sugar_black         #000000;
+@define-color sugar_toolbar_grey  #282828;
+@define-color sugar_button_grey   #808080;
+@define-color sugar_selection_grey #A6A6A6;
+@define-color sugar_panel_grey    #C0C0C0;
+@define-color sugar_text_field_grey #E5E5E5;
+@define-color sugar_row_even      #E5E5E5;
+@define-color sugar_row_odd       #D5D5D5;
+@define-color sugar_white         #FFFFFF;
+@define-color sugar_zoom_prelight #E8E8E8;
+@define-color sugar_zoom_active   #B3B3B3;
+
+@define-color theme_bg_color      #ededed;
+@define-color theme_fg_color      #2e3436;
+@define-color theme_base_color    @sugar_white;
+@define-color theme_text_color    #2e3436;
+@define-color theme_selected_bg_color #4a90d9;
+@define-color theme_selected_fg_color @sugar_white;
+@define-color theme_tooltip_bg_color  #343434;
+@define-color theme_tooltip_fg_color  @sugar_white;
+
+
+label,
+treeview,
+treeview cell,
+listview,
+listview cell,
+.view:not(VteTerminal),
+textview text {
+    color: @sugar_black;
+}
+
+VteTerminal,
+vte-terminal {
+    color: @sugar_white;
+}
+
+/* 2. GLOBAL RESET / DEFAULTS */
+
+* {
+    -gtk-icon-style: regular;
+    outline-offset: 0;
+    box-shadow: none;
+    text-shadow: none;
+}
+
+*:disabled {
+    color: @sugar_panel_grey;
+}
+
+
+/* 3. WINDOWS & DIALOGS */
+
+window {
+    background-color: @sugar_panel_grey;
+    color: @sugar_black;
+}
+
+window.SugarWindow,
+.sugar-window {
+    background-color: @sugar_panel_grey;
+    color: @sugar_black;
+}
+
+/* HOME VIEW and JOURNAL VIEW - Gtk.Box stack pages
+ * In GTK4, Gtk.Box doesn't inherit window background.
+ * These are children of the Shell Gtk.Stack (ApplicationWindow).
+ * HomeWindow (SugarViewToolbar parent box), JournalWindow (box)
+ * must have explicit background - otherwise they render as black/transparent. */
+
+SugarHomeWindow,
+SugarJournalWindow,
+.home-window,
+.journal-window {
+    background-color: @sugar_white;
+    color: @sugar_black;
+}
+
+.sugar-shell-stack {
+    background-color: @sugar_black;
+    color: @sugar_white;
+}
+
+listview,
+.listview,
+columnview {
+    background-color: @sugar_black;
+    color: @sugar_white;
+}
+
+listview > row,
+columnview > listview > row {
+    background-color: @sugar_row_even;
+    color: @sugar_black;
+}
+
+listview > row:nth-child(odd),
+columnview > listview > row:nth-child(odd) {
+    background-color: @sugar_row_odd;
+}
+
+listview > row:selected,
+columnview > listview > row:selected {
+    background-color: @sugar_selection_grey;
+    color: @sugar_black;
+}
+
+listview > row:hover,
+columnview > listview > row:hover {
+    background-color: @sugar_panel_grey;
+    color: @sugar_black;
+}
+
+.background-white {
+    background-color: @sugar_white;
+}
+
+.background-transparent {
+    background-color: transparent;
+}
+
+dialog {
+    background-color: @sugar_black;
+    color: @sugar_white;
+}
+
+window.introwindow,
+.intro-window {
+    background-color: @sugar_white;
+    color: @sugar_black;
+}
+
+/* Sugar Frame window */
+.framewindow,
+.notification-window,
+.sugar-frame-window {
+    background-color: @sugar_black;
+    color: @sugar_white;
+}
+
+
+label,
+label:disabled {
+    background-color: transparent;
+}
+
+
+/* 4. TOOLBAR / TOOLBOX  (from gtk-widgets.css.em "toolbar") */
+
+toolbar,
+.toolbar,
+.sugar-toolbarbox,
+.sugar-toolbar {
+    padding: 0;
+    background-color: @sugar_toolbar_grey;
+    color: @sugar_white;
+    min-height: 55px;  /* GRID_CELL_SIZE at 72% - 54px; keep 55 */
+}
+
+searchbar,
+ActivityChooserSearchBar {
+    background-color: @sugar_toolbar_grey;
+    color: @sugar_white;
+    border-top: 2px solid @sugar_button_grey;
+}
+
+/* Separator inside toolbar */
+toolbar separator,
+.sugar-toolbar separator {
+    background-color: transparent;
+    border-left: 2px solid @sugar_button_grey;
+    margin-left: 11px;
+    margin-right: 11px;
+    min-width: 2px;
+    min-height: 1px;
+}
+
+
+/* 5. TOOL BUTTONS  (ToolButton, ToolbarButton) */
+
+/* The ToolButton class adds CSS class "toolbar-button" and "flat".
+ * toolbutton is the standard GTK4 CSS node for GtkToolButton-style items.
+ */
+
+toolbutton > button,
+.toolbar-button {
+    border-style: none;
+    background-color: transparent;
+    border-radius: 7px;              /* toolbutton_padding=7 */
+    padding: 3px;                    /* toolbutton_padding - default_padding = 7-4 */
+    margin: 4px;                     /* default_padding */
+    min-width: 33px;                 /* SMALL_ICON_SIZE at 72% */
+    min-height: 33px;
+    color: @sugar_white;
+}
+
+toolbutton > button:hover:not(:checked),
+.toolbar-button:hover:not(:checked) {
+    background-color: @sugar_black;
+    border-style: solid;
+    border-width: 2px;
+    border-color: transparent;
+    padding: 1px;                    /* compensate 2px border */
+}
+
+/* Active / pressed */
+toolbutton > button:active,
+.toolbar-button:active {
+    background-color: @sugar_button_grey;
+    border-radius: 7px;
+    color: @sugar_white;
+}
+
+/* Checked / toggled */
+toolbutton > button:checked,
+.toolbar-button:checked {
+    background-color: @sugar_button_grey;
+    border-radius: 7px;
+    color: @sugar_white;
+}
+
+toolbutton > button:checked:hover,
+.toolbar-button:checked:hover {
+    background-color: @sugar_button_grey;
+    border-color: @sugar_button_grey;
+}
+
+/* Disabled / insensitive */
+toolbutton > button:disabled,
+.toolbar-button:disabled {
+    opacity: 0.5;
+}
+
+/* Focus ring */
+toolbutton > button:focus-visible,
+.toolbar-button:focus-visible {
+    outline: 2px solid @sugar_white;
+    outline-offset: 2px;
+}
+
+toolbutton > button #gtk-toolbar-arrow,
+.toolbar-button #gtk-toolbar-arrow {
+    padding: 0 15px;   /* subcell_size + default_padding = 11+4 */
+}
+
+/* Expandable toolbar button states */
+.toolbar-expandable-button {
+    margin: 2px;
+    border-radius: 4px;
+}
+
+.toolbar-expandable-button.expanded {
+    background-color: alpha(@sugar_button_grey, 0.2);
+    border-bottom: 2px solid @sugar_button_grey;
+}
+
+.palette-down,
+.toolbar-down {
+    border-style: solid;
+    border-width: 2px;
+    border-color: @sugar_button_grey;
+}
+
+
+/* 6. REGULAR BUTTONS */
+
+button {
+    /* border = ceil((3*subcell_size/2 - icon_small/2))
+       At 72%: (3*11/2 - 24/2) = 16.5-12 = 4.5 - ceil = 5 */
+    padding: 5px;
+    border-width: 2px;
+    border-color: @sugar_button_grey;
+    border-style: solid;
+    border-radius: 22px;             /* 2 * subcell_size = 22 */
+    background-color: @sugar_button_grey;
+    color: @sugar_white;
+}
+
+button:focus-visible {
+    outline: 2px solid @sugar_white;
+    outline-offset: 2px;
+    border-color: @sugar_white;
+}
+
+button:disabled {
+    background-color: transparent;
+}
+
+button:active {
+    background-color: @sugar_white;
+    color: @sugar_black;
+}
+
+button:checked {
+    background-color: @sugar_white;
+    color: @sugar_black;
+}
+
+button:active:focus-visible,
+button:checked:focus-visible {
+    color: @sugar_black;
+    border-color: @sugar_button_grey;
+}
+
+/* Unfullscreen button */
+.unfullscreen-button {
+    border-radius: 50%;
+    padding: 4px;
+    background-color: alpha(@sugar_button_grey, 0.85);
+    color: @sugar_white;
+    border: none;
+}
+
+.unfullscreen-button:hover {
+    background-color: @sugar_black;
+}
+
+
+/* 7. SPIN BUTTONS */
+
+spinbutton button {
+    border: none;
+    margin: 11px 0;              /* subcell_size */
+    background-color: @sugar_button_grey;
+    color: @sugar_white;
+}
+
+spinbutton button:last-child {
+    border-radius: 0 22px 22px 0;
+    border-left: 2px solid @sugar_selection_grey;
+}
+
+spinbutton entry {
+    background-color: @sugar_selection_grey;
+    margin: 11px;
+    margin-right: 0;
+    border-color: @sugar_button_grey;
+    color: @sugar_black;
+}
+
+spinbutton entry:focus {
+    background-color: @sugar_button_grey;
+}
+
+spinbutton button:active,
+spinbutton button:focus {
+    border: none;
+}
+
+
+/* 8. TEXT ENTRIES */
+
+entry,
+sugariconentry,
+sugar-icon-entry {
+    border-radius: 22px;         /* 2 * subcell_size */
+    border-width: 2px;
+    border-color: @sugar_text_field_grey;
+    border-style: solid;
+    background-color: @sugar_text_field_grey;
+    color: @sugar_black;
+    caret-color: @sugar_black;
+    padding: 6px 8px;
+}
+
+entry > text,
+searchentry > text,
+sugariconentry > text,
+sugar-icon-entry > text {
+    background-color: transparent;
+    color: inherit;
+}
+
+entry image,
+sugariconentry image,
+sugar-icon-entry image {
+    margin: 3px;                 /* default_padding - 1 */
+}
+
+toolbar entry,
+.sugar-toolbar entry,
+toolbar sugariconentry,
+.sugar-toolbar sugariconentry,
+toolbar sugar-icon-entry,
+.sugar-toolbar sugar-icon-entry {
+    margin: 11px;                /* subcell_size */
+}
+
+entry:focus,
+sugariconentry:focus,
+sugar-icon-entry:focus {
+    background-color: @sugar_white;
+}
+
+toolbar entry:focus,
+.sugar-toolbar entry:focus,
+toolbar sugariconentry:focus,
+.sugar-toolbar sugariconentry:focus,
+toolbar sugar-icon-entry:focus,
+.sugar-toolbar sugar-icon-entry:focus {
+    border-color: @sugar_white;
+}
+
+entry:disabled,
+sugariconentry:disabled,
+sugar-icon-entry:disabled {
+    background-color: @sugar_button_grey;
+    border-color: @sugar_button_grey;
+}
+
+entry progress,
+sugariconentry progress,
+sugar-icon-entry progress {
+    border-radius: 22px;
+    border-width: 2px;
+    background-color: @sugar_selection_grey;
+}
+
+entry:selected,
+entry:selected:focus,
+sugariconentry:selected,
+sugariconentry:selected:focus,
+sugar-icon-entry:selected,
+sugar-icon-entry:selected:focus {
+    background-color: @sugar_selection_grey;
+    color: @sugar_black;
+    border-color: @sugar_selection_grey;
+}
+
+/* Text selection highlight */
+selection {
+    background-color: @theme_selected_bg_color;
+    color: @theme_selected_fg_color;
+}
+
+
+/* 9. VIEWS (treeview, listview, text) */
+
+.view,
+textview text {
+    border-width: 0;
+    border-style: none;
+    border-radius: 0;
+    padding: 0;
+    background-color: @sugar_white;
+    color: @sugar_black;
+    caret-color: @sugar_black;
+}
+
+treeview {
+    background-color: @sugar_white;
+    color: @sugar_black;
+}
+
+treeview header button,
+treeview header button:hover:active {
+    border-radius: 0;
+    background-color: @sugar_button_grey;
+    border-width: 0;
+    color: @sugar_white;
+}
+
+treeview:selected {
+    background-color: @sugar_panel_grey;
+    color: @sugar_black;
+}
+
+/* Alternating row colors */
+treeview row:nth-child(even) {
+    background-color: @sugar_row_even;
+}
+
+treeview row:nth-child(odd) {
+    background-color: @sugar_row_odd;
+}
+
+
+/* 10. FRAMES / SCROLLED WINDOWS */
+
+frame {
+    border-style: solid;
+    border-color: @sugar_selection_grey;
+    border-width: 2px;
+    border-radius: 0;
+    padding: 4px;                /* default_padding */
+}
+
+frame.journal-preview-box {
+    border-color: @sugar_button_grey;
+}
+
+scrolledwindow {
+    background-color: transparent;
+}
+
+.palette-popover scrolledwindow,
+.palette-popover scrolledwindow > viewport {
+    background-color: @sugar_black;
+}
+
+
+/* 11. SCROLLBARS */
+
+scrollbar {
+    background-color: transparent;
+}
+
+scrollbar trough {
+    background-color: @sugar_button_grey;
+    border-width: 0;
+}
+
+scrollbar slider {
+    background-color: @sugar_white;
+    border-radius: 22px;         /* 2 * subcell_size */
+    border-width: 2px;
+    border-color: @sugar_button_grey;
+    border-style: solid;
+}
+
+/* Minimum sizes - vertical */
+scrollbar.vertical slider {
+    min-width: 11px;             /* subcell_size */
+    min-height: 33px;            /* 3 * subcell_size */
+}
+
+/* Minimum sizes - horizontal */
+scrollbar.horizontal slider {
+    min-height: 11px;
+    min-width: 33px;
+}
+
+scrollbar slider:active {
+    background-color: @sugar_text_field_grey;
+}
+
+scrollbar button {
+    min-width: 0;
+    min-height: 0;
+    padding: 0;
+    border: none;
+    opacity: 0;
+}
+
+
+/* 12. PROGRESS BARS */
+
+progressbar progress {
+    min-height: 11px;
+    min-width: 11px;
+    background-color: @sugar_white;
+    border-radius: 11px;         /* subcell_size */
+}
+
+progressbar trough {
+    min-height: 11px;
+    min-width: 11px;
+    background-color: @sugar_selection_grey;
+    border-style: solid;
+    border-radius: 11px;
+    border-color: @sugar_button_grey;
+    border-width: 2px;
+}
+
+toolbar progressbar trough,
+.sugar-toolbar progressbar trough,
+.palette-popover progressbar trough {
+    background-color: @sugar_black;
+}
+
+/* Cell progress bars */
+.cell.progressbar,
+.cell.trough {
+    border-style: solid;
+    border-width: 2px;
+    border-color: @sugar_selection_grey;
+    border-radius: 22px;
+}
+
+.cell.progressbar {
+    background-color: @sugar_white;
+}
+
+.cell.trough {
+    background-color: @sugar_text_field_grey;
+}
+
+
+/* 13. SEPARATORS */
+
+separator {
+    background-color: @sugar_button_grey;
+    min-width: 2px;
+    min-height: 2px;
+}
+
+/* Horizontal separator inside palette */
+.palette-popover separator.horizontal {
+    border-top: 2px solid @sugar_button_grey;
+    margin-top: 11px;
+    margin-bottom: -11px;
+    background-color: transparent;
+}
+
+
+/* 14. MENUS  (popover menus and palette menus) */
+
+menu {
+    background-color: @sugar_black;
+    color: @sugar_white;
+    padding: 0;
+    border: 2px solid @sugar_button_grey;
+}
+
+menuitem {
+    padding: 11px 8px;    /* subcell_size -- (3*subcell_size - font_height)/2 at 72% - 11px 8px */
+    color: @sugar_white;
+}
+
+menuitem:hover {
+    background-color: @sugar_button_grey;
+    color: @sugar_white;
+}
+
+menuitem separator {
+    padding: 0;
+}
+
+/* All GTK4 popovers */
+popover > contents {
+    background-color: @sugar_black;
+    color: @sugar_white;
+    border: 2px solid @sugar_button_grey;
+    border-radius: 4px;
+    padding: 0;
+}
+
+popover > arrow {
+    background-color: @sugar_black;
+    border: 2px solid @sugar_button_grey;
+}
+
+popover.menu modelbutton {
+    padding: 8px 11px;
+    color: @sugar_white;
+    border-radius: 0;
+}
+
+popover.menu modelbutton:hover {
+    background-color: @sugar_button_grey;
+}
+
+
+/* 15. PALETTES  (SugarPaletteWindowWidget, SugarPaletteMenuWidget)
+ *
+ * GTK4: GType names work as CSS element selectors.
+ * SugarPaletteWindowWidget - _PaletteWindowWidget (Gtk.Popover)
+ * SugarPaletteMenuWidget   - _PaletteMenuWidget   (Gtk.Popover)
+ * Also add css class "palette-popover" for extra specificity.
+ *
+ * Mirrors GTK3 sugar-artwork/gtk3/theme/gtk-widgets.css.em:
+ *   SugarPaletteWindowWidget, GtkPopover { background-color: @black; ... }
+ *   SugarPaletteMenuWidget { background-color: @black; } */
+
+/*  Palette window & menu widget: black bg, grey border 
+ * Target both GType names AND css class AND popover > contents node */
+SugarPaletteWindowWidget,
+SugarPaletteMenuWidget,
+popover.palette-popover {
+    background-color: transparent;
+    border: none;
+}
+
+SugarPaletteWindowWidget > contents,
+SugarPaletteMenuWidget > contents,
+popover.palette-popover > contents {
+    background-color: @sugar_black;
+    color: @sugar_white;
+    border-radius: 0;
+    padding: 0;
+    border-width: 2px;
+    border-color: @sugar_button_grey;
+    border-style: solid;
+}
+
+SugarPaletteWindowWidget > arrow,
+SugarPaletteMenuWidget > arrow,
+popover.palette-popover > arrow {
+    background-color: @sugar_black;
+    border: none;
+}
+
+SugarPaletteWindowWidget label,
+SugarPaletteMenuWidget label,
+.palette-popover label {
+    color: @sugar_white;
+}
+
+SugarPaletteWindowWidget > contents > box > box:first-child,
+.palette-popover > contents > box > box:first-child {
+    background-color: @sugar_black;
+    color: @sugar_white;
+    border-bottom: 1px solid @sugar_button_grey;
+    min-height: 47px;
+}
+
+/*  Buttons inside palettes (RadioToolButton, ToolButton, flat) 
+ * Mirrors GTK3: .toolbar GtkToolButton .button, SugarPaletteWindowWidget GtkToolButton .button */
+SugarPaletteWindowWidget button,
+SugarPaletteMenuWidget button,
+.palette-popover button {
+    background-color: transparent;
+    color: @sugar_white;
+    border-color: transparent;
+    border-style: none;
+}
+
+SugarPaletteWindowWidget button:hover,
+SugarPaletteMenuWidget button:hover,
+.palette-popover button:hover {
+    background-color: @sugar_black;
+    color: @sugar_white;
+}
+
+SugarPaletteWindowWidget button:checked,
+SugarPaletteWindowWidget button:active,
+SugarPaletteMenuWidget button:checked,
+SugarPaletteMenuWidget button:active,
+.palette-popover button:checked,
+.palette-popover button:active {
+    background-color: @sugar_button_grey;
+    color: @sugar_white;
+    border-radius: 7px;
+}
+
+SugarPaletteWindowWidget button image,
+SugarPaletteMenuWidget button image,
+.palette-popover button image {
+    color: @sugar_white;
+}
+
+SugarPaletteWindowWidget .sugar-group-box,
+.palette-popover .sugar-group-box {
+    background-color: @sugar_toolbar_grey;
+    color: @sugar_white;
+}
+
+SugarPaletteWindowWidget .view,
+.palette-popover .view {
+    color: @sugar_black;
+    background-color: @sugar_white;
+}
+
+.palette-action-bar {
+    background-color: @sugar_toolbar_grey;
+    padding: 4px;
+}
+
+/*  PaletteMenuItem row (button.palette-menu-item) 
+ * Mirrors GTK3: .menuitem { padding: subcell_size ... }
+ *               .menuitem:prelight { background-color: @button_grey } */
+.palette-menu-item {
+    padding: 8px 11px;
+    color: @sugar_white;
+    background-color: transparent;
+    border: none;
+    border-radius: 0;
+    min-height: 30px;
+}
+
+.palette-menu-item:hover {
+    background-color: @sugar_button_grey;
+    color: @sugar_white;
+}
+
+.palette-menu-item label {
+    color: @sugar_white;
+}
+
+.palette-menu-item image {
+    color: @sugar_white;
+}
+
+separator.palette-menu-separator {
+    margin: 2px 6px;
+    min-height: 2px;
+    background-color: @sugar_button_grey;
+    color: @sugar_button_grey;
+    border: none;
+}
+
+.palette-menu-box,
+.palette-menu {
+    background-color: @sugar_black;
+    color: @sugar_white;
+}
+
+.palette-menu-box *,
+.palette-menu * {
+    color: @sugar_white;
+}
+
+.palette-content-box {
+    background-color: @sugar_toolbar_grey;
+    color: @sugar_white;
+    padding: 4px;
+}
+
+SugarPaletteWindowWidget scrolledwindow,
+SugarPaletteMenuWidget scrolledwindow {
+    background-color: @sugar_black;
+}
+
+
+tooltip {
+    background-color: @sugar_black;
+    border: 2px solid @sugar_button_grey;
+    border-radius: 4px;
+    color: @sugar_white;
+    padding: 4px 8px;
+}
+
+tooltip * {
+    color: @sugar_white;
+}
+
+tooltip box {
+    background-color: @sugar_black;
+}
+
+
+/* 17. NOTEBOOKS / TOOLBOX TABS */
+
+notebook {
+    background-color: @sugar_selection_grey;
+    color: @sugar_black;
+    padding: 0;
+}
+
+notebook tab {
+    background-color: @sugar_selection_grey;
+}
+
+notebook tab label {
+    color: @sugar_white;
+    padding: 11px 0;     /* subcell_size */
+}
+
+notebook tab button label {
+    color: @sugar_black;
+}
+
+notebook tab:checked {
+    background-color: @sugar_toolbar_grey;
+}
+
+notebook tab button {
+    border-radius: 7px;  /* toolbutton_padding */
+}
+
+notebook arrow {
+    color: @sugar_white;
+}
+
+
+/* 18. COMBO BOXES
+ * GTK4 ComboBox structure:
+ *   combobox > button.combo > box > cellview
+ *                                 > arrow
+ * In control panels, these should be grey bg + white text,
+ * matching GTK3 sugar-artwork button_grey (#808080) style. */
+
+
+combobox > popover,
+combobox > popover > contents,
+dropdown popover,
+dropdown popover > contents {
+    background-color: @sugar_black;
+    color: @sugar_white;
+    border: 2px solid @sugar_button_grey;
+    border-radius: 4px;
+    padding: 0;
+}
+
+combobox > popover > contents row,
+combobox > popover > contents modelbutton,
+dropdown popover > contents row {
+    background-color: @sugar_black;
+    color: @sugar_white;
+    padding: 6px 10px;
+    border-radius: 0;
+}
+
+combobox > popover > contents row:hover,
+combobox > popover > contents modelbutton:hover,
+dropdown popover > contents row:hover {
+    background-color: @sugar_button_grey;
+    color: @sugar_white;
+}
+
+combobox > popover > contents row:selected,
+combobox > popover > contents modelbutton:checked {
+    background-color: @sugar_selection_grey;
+    color: @sugar_black;
+}
+
+toolbar combobox button.combo,
+.sugar-toolbar combobox button.combo {
+    border-radius: 22px;
+}
+
+
+/* 19. SCALES / SLIDERS */
+
+scale trough {
+    background-color: @sugar_button_grey;
+    border-style: solid;
+    border-color: @sugar_button_grey;
+    border-width: 2px;
+    border-radius: 22px;
+    margin: 6px 0;               /* scale_trough_margin at 72% */
+}
+
+scale.vertical trough {
+    margin: 0 6px;
+}
+
+scale highlight {
+    background-color: @sugar_white;
+    border-style: solid;
+    border-color: @sugar_button_grey;
+    border-width: 2px;
+    border-radius: 22px;
+}
+
+scale slider {
+    background-color: @sugar_white;
+    border: 2px solid @sugar_button_grey;
+    border-radius: 50%;
+    margin: -5px;                /* -floor(subcell_size/2) */
+    min-width: 22px;             /* 2 * subcell_size */
+    min-height: 22px;
+}
+
+scale slider:active {
+    background-color: @sugar_button_grey;
+    border-color: @sugar_white;
+    margin: -5px;
+    min-width: 22px;
+    min-height: 22px;
+}
+
+.transparent {
+    background-color: transparent;
+}
+
+.sugar-group-box {
+    background-color: @sugar_selection_grey;
+    color: @sugar_black;
+}
+
+window > box,
+window > grid {
+    background-color: inherit;
+}
+
+overlay {
+    background-color: transparent;
+}
+
+button.flat {
+    background-color: transparent;
+    border: none;
+}
+
+button.flat:hover {
+    background-color: alpha(@sugar_white, 0.1);
+}
+
+button.flat:active,
+button.flat:checked {
+    background-color: alpha(@sugar_white, 0.2);
+}
+
+
+
+/* CONTROL PANEL SECTION VIEW STYLES
+ * Section view background is white (like GTK3 SectionView).
+ * Buttons/comboboxes remain grey (GTK3 default button_grey).
+ * Labels/text are black (text_color). */
+.controlpanel-bg-black { background-color: @sugar_black; color: @sugar_white; }
+
+
+.cpanelsectionview {
+    background-color: @sugar_white;
+    color: @sugar_black;
+}
+
+.cpanelsectionview label,
+.cpanelsectionview text,
+.cpanelsectionview .view,
+.cpanelsectionview label:disabled,
+.cpanelsectionview text:disabled,
+.cpanelsectionview .view:disabled {
+    color: @sugar_black;
+    opacity: 1.0;
+    background-color: transparent;
+}
+
+.cpanelsectionview .dim-label {
+    opacity: 0.6;
+    color: @sugar_black;
+}
+
+.cpanelsectionview entry {
+    background-color: @sugar_text_field_grey;
+    color: @sugar_black;
+    border: 2px solid @sugar_button_grey;
+    border-radius: 22px;
+}
+
+/* CONTROL PANEL BUTTONS AND COMBOBOXES */
+
+.cpanelsectionview combobox,
+.cpanelsectionview dropdown {
+    background-image: none;
+    background-color: @sugar_button_grey;
+    color: @sugar_white;
+    border: 2px solid @sugar_button_grey;
+    border-radius: 22px;
+    box-shadow: none;
+    min-height: 28px;
+    padding: 4px 12px;
+}
+
+.cpanelsectionview combobox:hover,
+.cpanelsectionview dropdown:hover {
+    border-color: @sugar_white;
+}
+
+.cpanelsectionview combobox:active,
+.cpanelsectionview combobox:focus,
+.cpanelsectionview dropdown:active,
+.cpanelsectionview dropdown:focus {
+    border-color: @sugar_white;
+    background-color: @sugar_white;
+    color: @sugar_black;
+}
+
+.cpanelsectionview button {
+    background-image: none;
+    background-color: @sugar_button_grey;
+    color: @sugar_white;
+    border: 2px solid @sugar_button_grey;
+    border-radius: 22px;
+    box-shadow: none;
+    min-height: 28px;
+    padding: 4px 12px;
+}
+
+.cpanelsectionview button:hover {
+    border-color: @sugar_white;
+    background-color: @sugar_button_grey;
+    color: @sugar_white;
+}
+
+.cpanelsectionview button:active,
+.cpanelsectionview button:focus {
+    border-color: @sugar_white;
+    background-color: @sugar_white;
+    color: @sugar_black;
+}
+
+.cpanelsectionview combobox button,
+.cpanelsectionview dropdown button {
+    background-color: transparent;
+    background-image: none;
+    border: none;
+    box-shadow: none;
+    padding: 0;
+}
+
+.cpanelsectionview combobox *,
+.cpanelsectionview dropdown * {
+    color: @sugar_white;
+    opacity: 1.0;
+}
+
+.cpanelsectionview combobox:active *,
+.cpanelsectionview combobox:focus *,
+.cpanelsectionview dropdown:active *,
+.cpanelsectionview dropdown:focus * {
+    color: @sugar_black;
+    opacity: 1.0;
+}
+
+.cpanelsectionview button cellview,
+.cpanelsectionview button cellview *,
+.cpanelsectionview button image,
+.cpanelsectionview button label {
+    background-color: transparent;
+    color: @sugar_white;
+    opacity: 1.0;
+}
+
+.cpanelsectionview button:active cellview,
+.cpanelsectionview button:active cellview *,
+.cpanelsectionview button:active image,
+.cpanelsectionview button:active label,
+.cpanelsectionview button:checked cellview,
+.cpanelsectionview button:checked cellview *,
+.cpanelsectionview button:checked image,
+.cpanelsectionview button:checked label {
+    color: @sugar_black;
+    opacity: 1.0;
+}
+
+.cpanelsectionview button:focus cellview,
+.cpanelsectionview button:focus cellview *,
+.cpanelsectionview button:focus image,
+.cpanelsectionview button:focus label {
+    color: @sugar_white;
+    opacity: 1.0;
+}
+
+.cpanelsectionview button arrow,
+.cpanelsectionview combobox arrow,
+.cpanelsectionview dropdown arrow {
+    color: @sugar_white;
+    opacity: 1.0;
+}
+
+
+
+.sugar-inline-alert {
+    background: @sugar_selection_grey;
+    border-radius: 4px;
+    padding: 4px;
+}
+.inline-alert-label,
+.sugar-inline-alert label {
+    color: @sugar_black;
+}
+
+
+
+.sectionicon-transparent { background-color: transparent; }
+.sectionicon-label { color: @sugar_white; }
+
+.sugar-inline-alert { background-color: @sugar_selection_grey; }
+
+#clear-message-box { background-color: @sugar_white; }
+
+.transparent-window { 
+    background-color: transparent;
+    box-shadow: none;
+    border: none;
+    outline: none;
+}
+
+.notification-window { background-color: @sugar_toolbar_grey; }
+
+button.intro-nav-button { background: #A6A6A6; color: white; border-radius: 24px; }
+button.intro-nav-button:hover { background: #8C8C8C; }
+button.intro-nav-button:disabled { background: #E0E0E0; color: #A0A0A0; }
+
+.detailview-bg-panel { background-color: @sugar_panel_grey; }
+.detailview-bg-selection { background-color: @sugar_selection_grey; }
+
+.expandedentry-bg-panel { background-color: @sugar_panel_grey; }
+.expandedentry-bg-white { background-color: @sugar_white; }
+
+.iconview-bg-white { background-color: @sugar_white; }
+
+.bg-white { background-color: @sugar_white; }
+
+.modal-bg { background-color: alpha(@sugar_black, 0.85); color: @sugar_white; }
+
+.project-view-bg { background-color: @sugar_white; }
+
+.launch-window { background-color: @sugar_white; }
+
+textview text.source-view-text {
+    font-size: 14pt;
+}
+
+.launch-window { background-color: @sugar_black; }
+
+/* 20. RADIO AND CHECK BUTTONS */
+
+checkbutton check {
+    min-width: 18px;    /* radio_size */
+    min-height: 18px;
+    margin: 3px;
+    background-color: transparent;
+    background-image: url("assets/checkbox-unchecked.svg");
+    background-size: contain;
+    background-position: center;
+    background-repeat: no-repeat;
+}
+
+checkbutton radio {
+    min-width: 18px;    /* radio_size */
+    min-height: 18px;
+    margin: 3px;
+    background-color: transparent;
+    background-image: url("assets/radio.svg");
+    background-size: contain;
+    background-position: center;
+    background-repeat: no-repeat;
+}
+
+checkbutton check:checked {
+    background-image: url("assets/checkbox-checked.svg");
+    background-color: @sugar_button_grey;
+}
+
+checkbutton radio:checked {
+    background-image: url("assets/radio-active.svg");
+    background-color: @sugar_button_grey;
+}
+
+checkbutton:hover check,
+checkbutton:hover radio {
+    background-color: alpha(@sugar_black, 0.2);
+}
+
+toolbar checkbutton check,
+.sugar-toolbar checkbutton check,
+.palette-popover checkbutton check,
+toolbar checkbutton radio,
+.sugar-toolbar checkbutton radio,
+.palette-popover checkbutton radio {
+    color: @sugar_white;
+    border: 1px solid @sugar_white;
+}
+
+/* 21. LINKED WIDGETS */
+
+box.linked > *:not(:first-child):not(:last-child) {
+    border-radius: 0;
+}
+
+box.linked.horizontal > *:first-child:not(:last-child) {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+}
+
+box.linked.horizontal > *:not(:first-child):last-child {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+}
+
+box.linked.vertical > *:first-child:not(:last-child) {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+}
+
+box.linked.vertical > *:not(:first-child):last-child {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+}
+
+/* 22. MISCELLANEOUS (Browse, Control Panel, Tray, Alert) */
+
+.BrowseSearchWindow treeview {
+    background-color: @sugar_black;
+    color: @sugar_white;
+    border-color: @sugar_button_grey;
+    border-width: 0 2px 2px 2px;
+    border-style: solid;
+}
+
+.controlpanel image:disabled {
+    opacity: 0.5;
+}
+
+.htray, .vtray {
+    background-color: @sugar_toolbar_grey;
+}
+
+.htray *, .vtray * {
+    background-color: @sugar_toolbar_grey;
+}
+
+button .timeouticon label,
+button .timeouticon label:hover {
+    background-color: @sugar_white;
+    color: @sugar_button_grey;
+    border-radius: 22px;
+}
+
+button:active .timeouticon label {
+    background-color: @sugar_toolbar_grey;
+    color: @sugar_white;
+}
+
+.sugar-alert {
+    background-color: @sugar_black;
+    color: @sugar_white;
+}
+
+.sugar-alert *:disabled {
+    background-color: @sugar_black;
+}
+
+.sugar-alert button {
+    background-image: none;
+    background-color: @sugar_toolbar_grey;
+    color: @sugar_white;
+    border: 2px solid @sugar_button_grey;
+    border-radius: 22px;
+    min-height: 28px;
+    padding: 4px 12px;
+}
+
+.sugar-alert button label {
+    color: @sugar_white;
+}
+
+.sugar-alert button:hover {
+    background-color: @sugar_button_grey;
+    border-color: @sugar_white;
+}
+
+.sugar-alert button:active,
+.sugar-alert button:focus {
+    background-color: @sugar_black;
+    border-color: @sugar_white;
+    color: @sugar_white;
+}
+
+/* HOME VIEW - Background & Toolbar Contrast
+ * SugarViewToolbar uses 'sugar-toolbar' CSS class (dark background).
+ * Gtk.SearchEntry inside it needs explicit contrast. */
+
+SugarViewToolbar,
+.sugar-toolbar.SugarViewToolbar {
+    background-color: @sugar_toolbar_grey;
+    color: @sugar_white;
+    min-height: 55px;
+    padding: 4px;
+}
+
+SugarViewToolbar entry,
+SugarViewToolbar searchentry,
+.SugarViewToolbar entry,
+.SugarViewToolbar searchentry,
+.sugar-toolbar.SugarViewToolbar entry,
+.sugar-toolbar.SugarViewToolbar searchentry {
+    background-color: @sugar_white;
+    color: @sugar_black;
+    border-radius: 22px;
+    padding: 6px 11px;
+    border: 2px solid @sugar_button_grey;
+    min-height: 36px;
+}
+
+SugarViewToolbar entry:focus,
+SugarViewToolbar searchentry:focus,
+.SugarViewToolbar entry:focus,
+.SugarViewToolbar searchentry:focus,
+.sugar-toolbar.SugarViewToolbar entry:focus,
+.sugar-toolbar.SugarViewToolbar searchentry:focus {
+    border-color: @sugar_black;
+    outline: none;
+}
+
+/* Placeholder text */
+SugarViewToolbar entry placeholder,
+SugarViewToolbar searchentry placeholder,
+.sugar-toolbar.SugarViewToolbar entry placeholder,
+.sugar-toolbar.SugarViewToolbar searchentry placeholder {
+    color: @sugar_button_grey;
+    opacity: 1;
+}
+
+/* End of sugar.css */
+
+/* Tray styling override to ensure grid alignment and prevent size warnings */
+.htray scrolledwindow, .vtray scrolledwindow {
+    padding: 0;
+    margin: 0;
+    border-style: none;
+    border-width: 0;
+}
+
+.htray viewport, .vtray viewport {
+    padding: 0;
+    margin: 0;
+    border-style: none;
+    border-width: 0;
+}
+
+.htray button.toolbar-button, .vtray button.toolbar-button,
+.htray button, .vtray button {
+    padding: 0;
+    margin: 0;
+    border-style: none;
+    border-width: 0;
+    min-width: 0;
+    min-height: 0;
+}
+
+/* Fix specificity override for labels inside dark containers */
+toolbar label,
+.toolbar label,
+.sugar-toolbar label,
+.sugar-toolbarbox label,
+.palette-action-bar label,
+.framewindow label,
+.sugar-frame-window label,
+.notification-window label,
+dialog label,
+.sugar-alert label,
+tooltip label,
+.palette-popover label,
+SugarPaletteWindowWidget label,
+SugarPaletteMenuWidget label,
+.palette-menu-box label,
+.palette-menu label {
+    color: @sugar_white;
+}
+
+/* Ensure labels inside buttons and comboboxes in Section Views inherit the button text color */
+.cpanelsectionview button label,
+.cpanelsectionview combobox label,
+.cpanelsectionview dropdown label,
+.cpanelsectionview button cellview,
+.cpanelsectionview button cellview * {
+    color: inherit;
+}
+
+/* Improve contrast of disabled text on white backgrounds */
+.cpanelsectionview *:disabled,
+.cpanelsectionview label:disabled,
+SugarHomeWindow *:disabled,
+SugarJournalWindow *:disabled,
+.home-window *:disabled,
+.journal-window *:disabled {
+    color: @sugar_button_grey;
+}
+
+/* Force typed text inside all input entries and search fields to be black */
+entry,
+entry > text,
+searchentry,
+searchentry text,
+searchentry entry,
+searchentry entry > text {
+    color: @sugar_black;
+}


### PR DESCRIPTION
This PR introduces the GTK4 theme implementation (`gtk4/theme/`) to support the ongoing GTK4 port of the Sugar desktop shell and toolkit.

### Key Changes
* **GTK4 Stylesheet:** Created `gtk4/theme/gtk.css` using modern GTK4 CSS nodes and selectors (e.g., popover-based menus, text fields, notebooks). This stylesheet also integrates the shell-specific styles previously managed in the core `sugar` repository.
* **Self-Contained Theme Assets:** Added checkbox, radio, and slider SVGs inside `gtk4/theme/assets/` to support both `sugar-72` (72 dpi) and `sugar-100` (100 dpi) target scaling configurations. The theme assets are kept self-contained within the `gtk4` directory to prevent cross-directory build-time dependencies and ensure clean packaging.
* **Build Integration:** Updated `configure.ac` and top-level `Makefile.am` to register the new directories and install the GTK4 stylesheets and assets under `/usr/share/themes/sugar-{72,100}/gtk-4.0/`.